### PR TITLE
Use the correct org/app structure for AppCenter’s app ID

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           appcenter crashes upload-symbols \
             --token "${{ secrets.APPCENTER_API_TOKEN }}" \
-            --app "Swiftcord" \
+            --app "Swiftcord/Swiftcord" \
             --xcarchive "Swiftcord.xcarchive"
 
 


### PR DESCRIPTION
Sorry, I missed this in #58.