### PR TITLE
Use official blurple color from Discord's Branding Guidelines

### DIFF
--- a/Swiftcord/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Swiftcord/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0x64",
-          "red" : "0x56"
+          "blue" : "0xF2",
+          "green" : "0x65",
+          "red" : "0x58"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
The blurple color from https://discord.com/branding is stated as being `#5865F2`, however Swiftcord currently uses `#5664FF`.