### PR TITLE
Account Switcher

### DIFF
--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -331,6 +331,7 @@
 		DA91017228C38EA300DD076B /* AccountRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRow.swift; sourceTree = "<group>"; };
 		DA91017528C3989E00DD076B /* AccountMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountMeta.swift; sourceTree = "<group>"; };
 		DA91017828C4726300DD076B /* AccountSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitcher.swift; sourceTree = "<group>"; };
+		DA91017D28C4A45200DD076B /* DiscordKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DiscordKit; path = ../DiscordKit; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA8B2849C0FA00059FD7 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
@@ -487,6 +488,7 @@
 		DA4A887B27C0AF3000720909 = {
 			isa = PBXGroup;
 			children = (
+				DA91017D28C4A45200DD076B /* DiscordKit */,
 				36004E1C283D63E500F0BA73 /* .swiftlint.yml */,
 				DA4A888627C0AF3000720909 /* Swiftcord */,
 				DA4A891727C4B0DF00720909 /* README.md */,

--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -331,7 +331,6 @@
 		DA91017228C38EA300DD076B /* AccountRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRow.swift; sourceTree = "<group>"; };
 		DA91017528C3989E00DD076B /* AccountMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountMeta.swift; sourceTree = "<group>"; };
 		DA91017828C4726300DD076B /* AccountSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitcher.swift; sourceTree = "<group>"; };
-		DA91017D28C4A45200DD076B /* DiscordKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = DiscordKit; path = ../DiscordKit; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA8B2849C0FA00059FD7 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
@@ -488,7 +487,6 @@
 		DA4A887B27C0AF3000720909 = {
 			isa = PBXGroup;
 			children = (
-				DA91017D28C4A45200DD076B /* DiscordKit */,
 				36004E1C283D63E500F0BA73 /* .swiftlint.yml */,
 				DA4A888627C0AF3000720909 /* Swiftcord */,
 				DA4A891727C4B0DF00720909 /* README.md */,

--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		DA91017428C38EA300DD076B /* AccountRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017228C38EA300DD076B /* AccountRow.swift */; };
 		DA91017628C3989E00DD076B /* AccountMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017528C3989E00DD076B /* AccountMeta.swift */; };
 		DA91017728C3989E00DD076B /* AccountMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017528C3989E00DD076B /* AccountMeta.swift */; };
+		DA91017928C4726300DD076B /* AccountSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017828C4726300DD076B /* AccountSwitcher.swift */; };
+		DA91017A28C4726300DD076B /* AccountSwitcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017828C4726300DD076B /* AccountSwitcher.swift */; };
 		DA974EA22835ED1200013CC2 /* DiscordKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA974EA12835ED1200013CC2 /* DiscordKit */; };
 		DA974EA42835ED1200013CC2 /* DiscordKitCommon in Frameworks */ = {isa = PBXBuildFile; productRef = DA974EA32835ED1200013CC2 /* DiscordKitCommon */; };
 		DA97BA8C2849C0FA00059FD7 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA97BA8B2849C0FA00059FD7 /* Cache.swift */; };
@@ -328,6 +330,7 @@
 		DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentUserFooter+.swift"; sourceTree = "<group>"; };
 		DA91017228C38EA300DD076B /* AccountRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRow.swift; sourceTree = "<group>"; };
 		DA91017528C3989E00DD076B /* AccountMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountMeta.swift; sourceTree = "<group>"; };
+		DA91017828C4726300DD076B /* AccountSwitcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSwitcher.swift; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA8B2849C0FA00059FD7 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
@@ -661,6 +664,7 @@
 				DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */,
 				DA91017228C38EA300DD076B /* AccountRow.swift */,
 				DA91017528C3989E00DD076B /* AccountMeta.swift */,
+				DA91017828C4726300DD076B /* AccountSwitcher.swift */,
 			);
 			path = AccountSwitcher;
 			sourceTree = "<group>";
@@ -1100,6 +1104,7 @@
 				36429987286801C900483D0A /* LottieView.swift in Sources */,
 				36429988286801C900483D0A /* Date+.swift in Sources */,
 				36429989286801C900483D0A /* UserSettingsProfileView.swift in Sources */,
+				DA91017A28C4726300DD076B /* AccountSwitcher.swift in Sources */,
 				3642998A286801C900483D0A /* ServerView.swift in Sources */,
 				3642998B286801C900483D0A /* SwiftcordApp.swift in Sources */,
 				368B6730287A20F800E37B33 /* ServerJoinView.swift in Sources */,
@@ -1174,6 +1179,7 @@
 				DA2384BF27CCBB26009E15E0 /* EmbedView.swift in Sources */,
 				E7AF1C29282FA3F7001F78DF /* Channel+.swift in Sources */,
 				DA2BD30E284CCC9800EBB8D6 /* Text+.swift in Sources */,
+				DA91017928C4726300DD076B /* AccountSwitcher.swift in Sources */,
 				DAB1E46C28A10BB100645FCD /* BetterImageView.swift in Sources */,
 				DAA57E242892270800C9A931 /* SwiftyGifNSView.swift in Sources */,
 				DA2BD30C284CB38B00EBB8D6 /* AppSettingsAppearanceView.swift in Sources */,

--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -176,6 +176,12 @@
 		DA7721FD2896BD4D0007BE26 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7721FC2896BD4D0007BE26 /* URL+.swift */; };
 		DA7721FE2896BD4D0007BE26 /* URL+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7721FC2896BD4D0007BE26 /* URL+.swift */; };
 		DA91016C28BF8F1F00DD076B /* CreditsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAB1E46928A0A59500645FCD /* CreditsView.swift */; };
+		DA91017028C38E0400DD076B /* CurrentUserFooter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */; };
+		DA91017128C38E0400DD076B /* CurrentUserFooter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */; };
+		DA91017328C38EA300DD076B /* AccountRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017228C38EA300DD076B /* AccountRow.swift */; };
+		DA91017428C38EA300DD076B /* AccountRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017228C38EA300DD076B /* AccountRow.swift */; };
+		DA91017628C3989E00DD076B /* AccountMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017528C3989E00DD076B /* AccountMeta.swift */; };
+		DA91017728C3989E00DD076B /* AccountMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91017528C3989E00DD076B /* AccountMeta.swift */; };
 		DA974EA22835ED1200013CC2 /* DiscordKit in Frameworks */ = {isa = PBXBuildFile; productRef = DA974EA12835ED1200013CC2 /* DiscordKit */; };
 		DA974EA42835ED1200013CC2 /* DiscordKitCommon in Frameworks */ = {isa = PBXBuildFile; productRef = DA974EA32835ED1200013CC2 /* DiscordKitCommon */; };
 		DA97BA8C2849C0FA00059FD7 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA97BA8B2849C0FA00059FD7 /* Cache.swift */; };
@@ -319,6 +325,9 @@
 		DA6E89EF2876BC7E00BB05E7 /* AppSettingsAdvancedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSettingsAdvancedView.swift; sourceTree = "<group>"; };
 		DA7720CF283F184100D3C335 /* NavigationCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCommands.swift; sourceTree = "<group>"; };
 		DA7721FC2896BD4D0007BE26 /* URL+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+.swift"; sourceTree = "<group>"; };
+		DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CurrentUserFooter+.swift"; sourceTree = "<group>"; };
+		DA91017228C38EA300DD076B /* AccountRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountRow.swift; sourceTree = "<group>"; };
+		DA91017528C3989E00DD076B /* AccountMeta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountMeta.swift; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA892848737C00059FD8 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DA97BA8B2849C0FA00059FD7 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
@@ -438,6 +447,7 @@
 		DA2384BD27CCB0FD009E15E0 /* User */ = {
 			isa = PBXGroup;
 			children = (
+				DA91016E28C38D4900DD076B /* AccountSwitcher */,
 				DA54D572284497CC00B11857 /* Profile */,
 				DA32EF2727C633FE00A9ED72 /* UserAvatarView.swift */,
 				DA520AC627D39A00009FD740 /* CurrentUserFooter.swift */,
@@ -643,6 +653,16 @@
 				DA7720CF283F184100D3C335 /* NavigationCommands.swift */,
 			);
 			path = Commands;
+			sourceTree = "<group>";
+		};
+		DA91016E28C38D4900DD076B /* AccountSwitcher */ = {
+			isa = PBXGroup;
+			children = (
+				DA91016F28C38E0400DD076B /* CurrentUserFooter+.swift */,
+				DA91017228C38EA300DD076B /* AccountRow.swift */,
+				DA91017528C3989E00DD076B /* AccountMeta.swift */,
+			);
+			path = AccountSwitcher;
 			sourceTree = "<group>";
 		};
 		DAA57E22289226F500C9A931 /* SwiftyGif */ = {
@@ -985,6 +1005,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA91017728C3989E00DD076B /* AccountMeta.swift in Sources */,
 				DAB1E48828A50D3600645FCD /* DefaultMessageView.swift in Sources */,
 				3642993E286801C900483D0A /* OnboardingView.swift in Sources */,
 				3642993F286801C900483D0A /* String+.swift in Sources */,
@@ -1013,6 +1034,7 @@
 				DACBD130287BDE9D00CED3EF /* DialogView.swift in Sources */,
 				36429952286801C900483D0A /* Persistence.swift in Sources */,
 				DAA57E21289221A700C9A931 /* SwiftyGifView.swift in Sources */,
+				DA91017128C38E0400DD076B /* CurrentUserFooter+.swift in Sources */,
 				36429953286801C900483D0A /* LoadingView.swift in Sources */,
 				DABD8BB82882E9E4008EE28F /* DateFormatter+.swift in Sources */,
 				36429954286801C900483D0A /* CurrentUser+.swift in Sources */,
@@ -1029,6 +1051,7 @@
 				3642995F286801C900483D0A /* ChannelButton.swift in Sources */,
 				36429960286801C900483D0A /* CacheModel.xcdatamodeld in Sources */,
 				36429961286801C900483D0A /* UserSettingsAccountView.swift in Sources */,
+				DA91017428C38EA300DD076B /* AccountRow.swift in Sources */,
 				36429962286801C900483D0A /* Bool+.swift in Sources */,
 				DAFD4711289A1FEB0075D71B /* AttachmentAudio.swift in Sources */,
 				36429963286801C900483D0A /* AppDelegate.swift in Sources */,
@@ -1098,6 +1121,7 @@
 				DA03DA3F284F1E9200257790 /* Keychain.swift in Sources */,
 				DAB53670285B693700DD9857 /* AnyTransition+.swift in Sources */,
 				E7AF1C27282FA3ED001F78DF /* Array.Channel+.swift in Sources */,
+				DA91017328C38EA300DD076B /* AccountRow.swift in Sources */,
 				DAA57E1D28920F1E00C9A931 /* SwiftyGifView.swift in Sources */,
 				DA520AC327D37873009FD740 /* MergePartialMessage.swift in Sources */,
 				DAB53665285ACED100DD9857 /* GitHubAPI.swift in Sources */,
@@ -1115,6 +1139,7 @@
 				DA4A889127C0AF3200720909 /* Persistence.swift in Sources */,
 				DA2384C627CD1921009E15E0 /* LoadingView.swift in Sources */,
 				DA54D5762844B9C500B11857 /* CurrentUser+.swift in Sources */,
+				DA91017028C38E0400DD076B /* CurrentUserFooter+.swift in Sources */,
 				DAB53668285AD11000DD9857 /* DiscordChannelButton.swift in Sources */,
 				DA520AD727D4D17A009FD740 /* MiscSettingsView.swift in Sources */,
 				DA32EF3F27C7C1D000A9ED72 /* MessageInputView.swift in Sources */,
@@ -1173,6 +1198,7 @@
 				DAB1E48728A50D3600645FCD /* DefaultMessageView.swift in Sources */,
 				DAAA22AF284DC0D700C1975E /* AppSettingsAccessibilityView.swift in Sources */,
 				DAFD4713289A202F0075D71B /* AttachmentProgress.swift in Sources */,
+				DA91017628C3989E00DD076B /* AccountMeta.swift in Sources */,
 				DABD8BB72882E9E0008EE28F /* DateFormatter+.swift in Sources */,
 				DA32EF3227C676FE00A9ED72 /* LottieLoopMode.swift in Sources */,
 				DAFD4710289A1FEB0075D71B /* AttachmentAudio.swift in Sources */,

--- a/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,7 +15,7 @@
       "location" : "https://github.com/SwiftcordApp/DiscordKit",
       "state" : {
         "branch" : "main",
-        "revision" : "d6a7e55cb3e67f86c7005214ad0d1f26efec8dcd"
+        "revision" : "8b86f707d896eabdb8d01ee55be5afbe12ef9423"
       }
     },
     {

--- a/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "discordkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftcordApp/DiscordKit",
+      "state" : {
+        "branch" : "main",
+        "revision" : "7e30c37b0b02001196909c6f9d64aa3e13169ce6"
+      }
+    },
+    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",
@@ -52,15 +61,6 @@
       "state" : {
         "revision" : "286edd1fa22505a9e54d170e9fd07d775ea233f2",
         "version" : "2.1.0"
-      }
-    },
-    {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
-        "version" : "1.0.0"
       }
     },
     {

--- a/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Swiftcord.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "discordkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftcordApp/DiscordKit",
-      "state" : {
-        "branch" : "main",
-        "revision" : "8b86f707d896eabdb8d01ee55be5afbe12ef9423"
-      }
-    },
-    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",
@@ -61,6 +52,15 @@
       "state" : {
         "revision" : "286edd1fa22505a9e54d170e9fd07d775ea233f2",
         "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Swiftcord/ButtonStyles/FlatButtonStyle.swift
+++ b/Swiftcord/ButtonStyles/FlatButtonStyle.swift
@@ -19,15 +19,15 @@ struct FlatButtonStyle: ButtonStyle {
 	@Environment(\.isEnabled) private var enabled: Bool
 
 	func makeBody(configuration: Configuration) -> some View {
-		let base: Color = customBase ?? (configuration.role == .destructive ? .red : .accentColor)
+		let base: Color = customBase ?? (configuration.role == .destructive ? .red : (prominent ? .accentColor : .init(nsColor: .controlColor)))
 		let pressedStyles = configuration.isPressed && !outlined
 		let hoverStyles = (hovered && !outlined) || (configuration.isPressed && outlined)
 		let accent = enabled
-			? base.modifyingHSB(
+			? (base.modifyingHSB(
 				1,
 				pressedStyles ? 0.98 : (hoverStyles ? 0.96 : 1),
 				pressedStyles ? 0.67 : (hoverStyles ? 0.76 : 1)
-			)
+			))
 			: .gray.opacity(0.25)
 		let background = outlined && !hovered ? .clear : accent
 

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -52,7 +52,7 @@ struct SwiftcordApp: App {
 										  : (selectedTheme == "light" ? .light : nil))
 					.onAppear {
 						guard gateway.socket == nil else { return }
-						guard let token = Keychain.load(key: SwiftcordApp.tokenKeychainKey) else {
+						guard let token = acctManager.getActiveToken() else {
 							state.attemptLogin = true
 							return
 						}

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -32,7 +32,7 @@ struct SwiftcordApp: App {
 	var body: some Scene {
 		WindowGroup {
 			if state.attemptLogin {
-				LoginView()
+				LoginView() // Doesn't matter if login view is big enough
 					.environmentObject(gateway)
 					.environmentObject(state)
 					.environmentObject(restAPI)
@@ -77,6 +77,7 @@ struct SwiftcordApp: App {
 				.environmentObject(gateway)
 				.environmentObject(restAPI)
 				.environmentObject(state)
+				.environmentObject(acctManager)
 				.preferredColorScheme(selectedTheme == "dark"
 									  ? .dark
 									  : (selectedTheme == "light" ? .light : .none))

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -35,6 +35,7 @@ struct SwiftcordApp: App {
 					.environmentObject(gateway)
 					.environmentObject(state)
 					.environmentObject(restAPI)
+					.navigationTitle("Login")
 			} else {
 				ContentView()
 					.overlay(LoadingView())

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -25,6 +25,7 @@ struct SwiftcordApp: App {
 	@StateObject private var gateway = DiscordGateway()
 	@StateObject private var restAPI = DiscordREST()
 	@StateObject private var state = UIState()
+	@StateObject private var acctManager = AccountSwitcher()
 
 	@AppStorage("theme") private var selectedTheme = "system"
 
@@ -35,6 +36,7 @@ struct SwiftcordApp: App {
 					.environmentObject(gateway)
 					.environmentObject(state)
 					.environmentObject(restAPI)
+					.environmentObject(acctManager)
 					.navigationTitle("Login")
 			} else {
 				ContentView()
@@ -42,6 +44,7 @@ struct SwiftcordApp: App {
 					.environmentObject(gateway)
 					.environmentObject(state)
 					.environmentObject(restAPI)
+					.environmentObject(acctManager)
 				// .environment(\.locale, .init(identifier: "zh-Hans"))
 				// .environment(\.managedObjectContext, persistenceController.container.viewContext)
 					.preferredColorScheme(selectedTheme == "dark"

--- a/Swiftcord/Utils/AnalyticsWrapper.swift
+++ b/Swiftcord/Utils/AnalyticsWrapper.swift
@@ -26,6 +26,8 @@ struct AnalyticsWrapper {
 		case networkInviteResolve = "network_action_invite_resolve"
 		case resolveInvite = "resolve_invite"
 		case supporterCTAClick = "supporter_cta_click" // Clicked on supporter CTA
+		case impressionLogin = "impression_user_login"
+		case impressionAccountSwitcher = "impression_multi_account_switch_landing"
 	}
 
 	static private func getBaseProps() -> [String: Any?] {
@@ -38,7 +40,7 @@ struct AnalyticsWrapper {
 
 	static private let log = Logger(category: "AnalyticsWrapper")
 
-	static func event(type: EventType, properties: [String: Any?]) {
+	static func event(type: EventType, properties: [String: Any?] = [:]) {
 		let combinedProps = getBaseProps().merging(properties) { $1 }
 
 		let typedProps = EventProperties()

--- a/Swiftcord/Utils/WebView.swift
+++ b/Swiftcord/Utils/WebView.swift
@@ -23,6 +23,7 @@ class WebViewModel: ObservableObject {
 }
 
 struct WebView: NSViewRepresentable {
+	let shrink: Bool
     public typealias NSViewType = WKWebView
     @EnvironmentObject var viewModel: WebViewModel
 
@@ -98,10 +99,14 @@ struct WebView: NSViewRepresentable {
               background-size: cover;
               background-position: center;
             }
+            form[class*="authBox-"]::before {
+              content: unset;
+            }
             form[class*="authBox-"] {
               background-color: rgba(0, 0, 0, .7)!important;
               -webkit-backdrop-filter: blur(24px) saturate(140%);
-              border-radius: 12px;
+              border-radius: \(shrink ? 0 : 12)px;
+              \(shrink ? "padding: 1rem;" : "")
             }
             .theme-dark {
               --input-background: rgba(0, 0, 0, .25)!important;

--- a/Swiftcord/Utils/WebView.swift
+++ b/Swiftcord/Utils/WebView.swift
@@ -142,8 +142,6 @@ struct WebView: NSViewRepresentable {
     }
 
     public func updateNSView(_ nsView: WKWebView, context: NSViewRepresentableContext<WebView>) {
-		print("update nsview")
-		print(shrunkShowingQR)
 		nsView.evaluateJavaScript(shrunkShowingQR
 								  ? "document.body.classList.add('qr-only')"
 								  : "document.body.classList.remove('qr-only')"

--- a/Swiftcord/Utils/WebView.swift
+++ b/Swiftcord/Utils/WebView.swift
@@ -99,10 +99,10 @@ struct WebView: NSViewRepresentable {
               background-size: cover;
               background-position: center;
             }
-            form[class*="authBox-"]::before {
+            form[class*="authBox-"]::before, section[class*="authBox-"]::before {
               content: unset;
             }
-            form[class*="authBox-"] {
+            form[class*="authBox-"], section[class*="authBox-"]  {
               background-color: rgba(0, 0, 0, .7)!important;
               -webkit-backdrop-filter: blur(24px) saturate(140%);
               border-radius: \(shrink ? 0 : 12)px;

--- a/Swiftcord/Utils/WebView.swift
+++ b/Swiftcord/Utils/WebView.swift
@@ -24,6 +24,8 @@ class WebViewModel: ObservableObject {
 
 struct WebView: NSViewRepresentable {
 	let shrink: Bool
+	let shrunkShowingQR: Bool
+
     public typealias NSViewType = WKWebView
     @EnvironmentObject var viewModel: WebViewModel
 
@@ -114,6 +116,17 @@ struct WebView: NSViewRepresentable {
             div[class^="select-"] > div > div:nth-child(2) {
               background-color: var(--input-background)!important;
             }
+
+            .qr-only div[class*="centeringWrapper-"]>div {
+              flex-direction: column;
+            }
+            .qr-only div[class*="mainLoginContainer-"]>div:nth-child(2) {
+              display: none;
+            }
+            .qr-only div[class*="qrLogin-"] {
+              display: block!important;
+              margin-top: 24px;
+            }
           `;
           document.body.appendChild(s);
         }
@@ -128,7 +141,14 @@ struct WebView: NSViewRepresentable {
         return webView
     }
 
-    public func updateNSView(_ nsView: WKWebView, context: NSViewRepresentableContext<WebView>) { }
+    public func updateNSView(_ nsView: WKWebView, context: NSViewRepresentableContext<WebView>) {
+		print("update nsview")
+		print(shrunkShowingQR)
+		nsView.evaluateJavaScript(shrunkShowingQR
+								  ? "document.body.classList.add('qr-only')"
+								  : "document.body.classList.remove('qr-only')"
+		)
+	}
 
     public func makeCoordinator() -> Coordinator {
         return Coordinator(viewModel)

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -165,7 +165,6 @@ struct ContentView: View {
 						skipWhatsNew = true
 					}
 					presentingOnboarding = true
-					print(whatsNewMarkdown ?? "")
 				}
 			}
         })
@@ -177,11 +176,15 @@ struct ContentView: View {
                 state.loadingState = .initial
                 log.debug("Attempting login")
             }
-            _ = gateway.onEvent.addHandler { (evt, _) in
+            _ = gateway.onEvent.addHandler { (evt, data) in
                 switch evt {
                 case .ready:
                     state.loadingState = .gatewayConn
-					accountsManager.onSignedIn(with: gateway.cache.user!)
+					guard let p = data as? ReadyEvt else {
+						log.critical("Could not cast data to ready event! This should never happen!")
+						return
+					}
+					accountsManager.onSignedIn(with: p.user)
                     fallthrough
                 case .resumed:
                     gateway.send(op: .voiceStateUpdate, data: GatewayVoiceStateUpdate(

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -180,11 +180,11 @@ struct ContentView: View {
                 switch evt {
                 case .ready:
                     state.loadingState = .gatewayConn
-					guard let p = data as? ReadyEvt else {
+					guard let payload = data as? ReadyEvt else {
 						log.critical("Could not cast data to ready event! This should never happen!")
 						return
 					}
-					accountsManager.onSignedIn(with: p.user)
+					accountsManager.onSignedIn(with: payload.user)
                     fallthrough
                 case .resumed:
                     gateway.send(op: .voiceStateUpdate, data: GatewayVoiceStateUpdate(

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -40,6 +40,7 @@ struct ContentView: View {
     @EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var restAPI: DiscordREST
     @EnvironmentObject var state: UIState
+	@EnvironmentObject var accountsManager: AccountSwitcher
 
 	@AppStorage("local.seenOnboarding") private var seenOnboarding = false
 	@AppStorage("local.previousBuild") private var prevBuild: String?
@@ -180,6 +181,7 @@ struct ContentView: View {
                 switch evt {
                 case .ready:
                     state.loadingState = .gatewayConn
+					accountsManager.onSignedIn(with: gateway.cache.user!)
                     fallthrough
                 case .resumed:
                     gateway.send(op: .voiceStateUpdate, data: GatewayVoiceStateUpdate(

--- a/Swiftcord/Views/LoadingView.swift
+++ b/Swiftcord/Views/LoadingView.swift
@@ -15,19 +15,9 @@ struct LoadingView: View {
 	@EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var restAPI: DiscordREST
 
-	let keyPrefixesToRemove = [
-		"lastCh.",
-		"local.",
-		"lastSelectedGuild",
-		"showSendBtn",
-		"stickerAlwaysAnim",
-		"theme",
-		"ttsRate"
-	]
-
 	private func logOut() {
 		for key in UserDefaults.standard.dictionaryRepresentation().keys {
-			for toRemove in keyPrefixesToRemove {
+			for toRemove in UserSettingsView.keyPrefixesToRemove {
 				if key.prefix(toRemove.count) == toRemove {
 					UserDefaults.standard.removeObject(forKey: key)
 					break
@@ -92,30 +82,22 @@ struct LoadingView: View {
 				.lottieLoopMode(.loop)
 				.if(colorScheme == .light) { view in view.colorInvert() }
 
-				if Int.random(in: 0..<1000000000) != 0 {
-					Text("loader.tip.header").font(.headline).textCase(.uppercase)
-					Text(.init(displayedTip))
-						.multilineTextAlignment(.center)
-						.padding(.top, 8)
-						.frame(maxWidth: 320)
-						.onAppear {
-							displayedTip = loadingTips.randomElement()! // Will never be nil because loadingTips can never be empty
-							withAnimation {
-								DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
-									showLogoutButton = true
-								}
+				let chance = Int.random(in: 0..<1000000000) == 0
+				Text("loader.tip.header").font(.headline).textCase(.uppercase)
+				Text(.init(displayedTip))
+					.multilineTextAlignment(.center)
+					.padding(.top, 8)
+					.frame(maxWidth: 320)
+					.onAppear {
+						displayedTip = chance
+							? "Please wait warmly..."
+							: loadingTips.randomElement()! // Will never be nil because loadingTips can never be empty
+						withAnimation {
+							DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
+								showLogoutButton = true
 							}
 						}
-				} else {
-					Text("Please wait warmly...").font(.headline)
-						.onAppear {
-							withAnimation {
-								DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
-									showLogoutButton = true
-								}
-							}
-						}
-				}
+					}
 			}
 
 			VStack {

--- a/Swiftcord/Views/LoadingView.swift
+++ b/Swiftcord/Views/LoadingView.swift
@@ -137,6 +137,16 @@ struct LoadingView: View {
 				print("Unable to start notifier")
 			}
 		}
+		.onChange(of: state.loadingState) { newState in
+			if newState == .initial {
+				showLogoutButton = false // Reset logout timeout for future loads
+				withAnimation {
+					DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
+						showLogoutButton = true
+					}
+				}
+			}
+		}
     }
 }
 

--- a/Swiftcord/Views/LoadingView.swift
+++ b/Swiftcord/Views/LoadingView.swift
@@ -16,17 +16,10 @@ struct LoadingView: View {
 	@EnvironmentObject var restAPI: DiscordREST
 
 	private func logOut() {
-		for key in UserDefaults.standard.dictionaryRepresentation().keys {
-			for toRemove in UserSettingsView.keyPrefixesToRemove {
-				if key.prefix(toRemove.count) == toRemove {
-					UserDefaults.standard.removeObject(forKey: key)
-					break
-				}
-			}
-		}
-		gateway.logout()
+		AccountSwitcher.clearAccountSpecificPrefKeys()
+		gateway.disconnect()
+		state.attemptLogin = true
 		Task { await restAPI.logOut() }
-		Keychain.remove(key: SwiftcordApp.tokenKeychainKey)
 	}
 
 	let reach = try? Reachability(hostname: "odin.cs.uga.edu")

--- a/Swiftcord/Views/LoginView.swift
+++ b/Swiftcord/Views/LoginView.swift
@@ -16,6 +16,8 @@ struct LoginView: View {
 	@State var tokenString: String = ""
 
 	var shrink = false
+	var showQR = false
+	var onLoggedIn: (() -> Void)?
 
 	@EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var restAPI: DiscordREST
@@ -25,7 +27,7 @@ struct LoginView: View {
     var body: some View {
 		ZStack {
 			if !tokenView {
-				WebView(shrink: shrink)
+				WebView(shrink: shrink, shrunkShowingQR: showQR)
 					.environmentObject(loginWVModel)
 
 				if !loginWVModel.didFinishLoading {
@@ -65,12 +67,13 @@ struct LoginView: View {
 			if let token = token {
 				acctManager.setPendingToken(token: token)
 				if state.loadingState == .messageLoad { // Switch account
-					gateway.socket?.close(code: .normalClosure)
+					gateway.disconnect()
 					state.loadingState = .initial
 				}
 				gateway.connect(token: token) // Reconnect to the socket with the new token
 				restAPI.setToken(token: token)
 				state.attemptLogin = false
+				if let onLoggedIn = onLoggedIn { onLoggedIn() }
 			}
 		}
     }

--- a/Swiftcord/Views/LoginView.swift
+++ b/Swiftcord/Views/LoginView.swift
@@ -15,6 +15,8 @@ struct LoginView: View {
 	@State var tokenCount = 0
 	@State var tokenString: String = ""
 
+	var shrink = false
+
 	@EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var restAPI: DiscordREST
 	@EnvironmentObject var state: UIState
@@ -22,7 +24,7 @@ struct LoginView: View {
     var body: some View {
 		ZStack {
 			if !tokenView {
-				WebView()
+				WebView(shrink: shrink)
 					.environmentObject(loginWVModel)
 
 				if !loginWVModel.didFinishLoading {
@@ -59,8 +61,7 @@ struct LoginView: View {
 			.keyboardShortcut("t", modifiers: [.command, .shift])
 			.hidden()
 		}
-		.frame(minWidth: 850, idealWidth: 950, minHeight: 500, idealHeight: 620)
-		.navigationTitle("Login")
+		.frame(minWidth: shrink ? 450 : 850, idealWidth: 950, minHeight: 500, idealHeight: 620)
 		.onChange(of: loginWVModel.token) { token in
 			if let token = token {
 				Keychain.save(key: SwiftcordApp.tokenKeychainKey, data: token)

--- a/Swiftcord/Views/LoginView.swift
+++ b/Swiftcord/Views/LoginView.swift
@@ -63,6 +63,9 @@ struct LoginView: View {
 			.hidden()
 		}
 		.frame(minWidth: shrink ? 450 : 850, idealWidth: 950, minHeight: 500, idealHeight: 620)
+		.onAppear {
+			AnalyticsWrapper.event(type: .impressionLogin)
+		}
 		.onChange(of: loginWVModel.token) { token in
 			if let token = token {
 				acctManager.setPendingToken(token: token)

--- a/Swiftcord/Views/Server/ServerView.swift
+++ b/Swiftcord/Views/Server/ServerView.swift
@@ -30,6 +30,7 @@ struct ServerView: View {
 	@StateObject var serverCtx: ServerContext
 
 	private func loadChannels() {
+		guard state.loadingState != .initial else { return } // Ensure gateway is connected before loading anything
 		guard let channels = serverCtx.guild?.channels?.discordSorted()
 		else { return }
 

--- a/Swiftcord/Views/Settings/User/UserSettingsProfileView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsProfileView.swift
@@ -20,7 +20,7 @@ struct UserSettingsProfileView: View {
 
 			HStack(alignment: .top) {
 				VStack(alignment: .leading) {
-					Text("ABOUT ME").font(.headline)
+					Text("About Me").textCase(.uppercase).font(.headline)
 					Text("You can use markdown and links if you'd like.").opacity(0.75)
 					GroupBox {
 						ScrollView {
@@ -33,16 +33,13 @@ struct UserSettingsProfileView: View {
 				}.frame(maxWidth: .infinity, alignment: .leading)
 
 				VStack(alignment: .leading) {
-					Text("PREVIEW").font(.headline)
+					Text("Preview").textCase(.uppercase).font(.headline)
 					MiniUserProfileView(
 						user: User(from: user),
-						profile: $profile,
-						guildRoles: nil,
-						guildID: "@me",
-						isWebhook: false,
-						loadError: false,
-						hideNotes: true
-					)
+						profile: $profile
+					) {
+						Text("Customising my profile").font(.headline).textCase(.uppercase)
+					}
 					.background(Color(NSColor.controlBackgroundColor))
 					.cornerRadius(8)
 					.shadow(color: .black.opacity(0.24), radius: 16, x: 0, y: 8)

--- a/Swiftcord/Views/Settings/User/UserSettingsView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsView.swift
@@ -16,26 +16,7 @@ struct UserSettingsView: View {
 	@State private var selectedLink: SidebarLink? = .account
     @EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var rest: DiscordREST
-
-	static let keyPrefixesToRemove = [
-		"lastCh.",
-		"local.",
-		"lastSelectedGuild"
-	]
-
-	private func logOut() {
-		for key in UserDefaults.standard.dictionaryRepresentation().keys {
-			for toRemove in UserSettingsView.keyPrefixesToRemove {
-				if key.prefix(toRemove.count) == toRemove {
-					UserDefaults.standard.removeObject(forKey: key)
-					break
-				}
-			}
-		}
-		gateway.logout()
-		Task { await rest.logOut() }
-		Keychain.remove(key: SwiftcordApp.tokenKeychainKey)
-	}
+	@EnvironmentObject var acctManager: AccountSwitcher
 
     var body: some View {
         NavigationView {
@@ -64,17 +45,7 @@ struct UserSettingsView: View {
 							   tag: SidebarLink.logOut, selection: $selectedLink) {
                     VStack(alignment: .leading, spacing: 16) {
                         Text("settings.user.logOut").font(.title)
-                        Text("settings.user.logOut.confirmation")
-						Text("Note: This will also delete your locally stored preferences")
-							.font(.caption)
-                        Button(role: .destructive) { logOut() } label: {
-                            Label(
-								"settings.user.logOut",
-								systemImage: "rectangle.portrait.and.arrow.right"
-							)
-                        }
-                        .controlSize(.small)
-                        .buttonStyle(FlatButtonStyle())
+                        Text("Use the account switcher (found by clicking on your profile at the bottom of the channel list) to log out, switch or add accounts!")
 
                         Spacer()
                     }

--- a/Swiftcord/Views/Settings/User/UserSettingsView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsView.swift
@@ -17,15 +17,15 @@ struct UserSettingsView: View {
     @EnvironmentObject var gateway: DiscordGateway
 	@EnvironmentObject var rest: DiscordREST
 
-	private let keyPrefixesToRemove = [
+	static let keyPrefixesToRemove = [
 		"lastCh.",
 		"local.",
-		"lastSelectedGuild",
+		"lastSelectedGuild"
 	]
 
 	private func logOut() {
 		for key in UserDefaults.standard.dictionaryRepresentation().keys {
-			for toRemove in keyPrefixesToRemove {
+			for toRemove in UserSettingsView.keyPrefixesToRemove {
 				if key.prefix(toRemove.count) == toRemove {
 					UserDefaults.standard.removeObject(forKey: key)
 					break

--- a/Swiftcord/Views/User/AccountSwitcher/AccountMeta.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountMeta.swift
@@ -1,0 +1,38 @@
+//
+//  AccountMeta.swift
+//  Swiftcord
+//
+//  Created by Vincent Kwok on 3/9/22.
+//
+
+import Foundation
+import DiscordKitCommon
+
+struct AccountMeta: Codable, Equatable {
+	let id: Snowflake
+	let discrim: String
+	let name: String
+	let avatar: URL
+
+	init(id: Snowflake, discrim: String, name: String, avatar: URL) {
+		self.id = id
+		self.discrim = discrim
+		self.name = name
+		self.avatar = avatar
+	}
+
+	init(user: CurrentUser) {
+		id = user.id
+		discrim = user.discriminator
+		name = user.username
+		avatar = user.avatarURL(size: 80)
+	}
+
+	private enum CodingKeys : String, CodingKey {
+		case discrim = "d", name = "n", avatar = "a", id = "i"
+	}
+
+	static func == (lhs: AccountMeta, rhs: AccountMeta) -> Bool {
+		return lhs.id == rhs.id
+	}
+}

--- a/Swiftcord/Views/User/AccountSwitcher/AccountMeta.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountMeta.swift
@@ -28,7 +28,7 @@ struct AccountMeta: Codable, Equatable {
 		avatar = user.avatarURL(size: 80)
 	}
 
-	private enum CodingKeys : String, CodingKey {
+	private enum CodingKeys: String, CodingKey {
 		case discrim = "d", name = "n", avatar = "a", id = "i"
 	}
 

--- a/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
@@ -6,21 +6,32 @@
 //
 
 import SwiftUI
+import DiscordKitCore
+import DiscordKit
+import DiscordKitCommon
+import os
 
 struct AccountRow: View {
-	let avatarURL: URL
-	let username: String
-	let discriminator: String
+	let meta: AccountMeta
 	let isCurrent: Bool
+
+	@Binding var switcherPresented: Bool
+
+	@EnvironmentObject var gateway: DiscordGateway
+	@EnvironmentObject var restAPI: DiscordREST
+	@EnvironmentObject var state: UIState
+	@EnvironmentObject var switcher: AccountSwitcher
+
+	static let log = Logger(category: "AccountRow")
 
 	var body: some View {
 		HStack(spacing: 8) {
-			BetterImageView(url: avatarURL)
+			BetterImageView(url: meta.avatar)
 				.clipShape(Circle())
 				.frame(width: 40, height: 40)
 			VStack(alignment: .leading) {
-				Text(verbatim: username).font(.title3)
-				+ Text("#\(discriminator)").foregroundColor(.secondary)
+				Text(verbatim: meta.name).font(.title3)
+				+ Text("#\(meta.discrim)").foregroundColor(.secondary)
 				if isCurrent {
 					Text("Active account")
 						.font(.headline)
@@ -28,6 +39,25 @@ struct AccountRow: View {
 				}
 			}
 			Spacer()
+
+			if !isCurrent {
+				Button {
+					switcher.setActiveAccount(id: meta.id)
+					guard let newToken = switcher.getActiveToken() else {
+						AccountRow.log.error("No active token associated with account. This should never happen!")
+						return
+					}
+					state.loadingState = .initial
+					gateway.disconnect()
+					restAPI.setToken(token: newToken)
+					gateway.connect(token: newToken)
+					switcherPresented = false
+				} label: {
+					Text("Switch")
+				}
+				.buttonStyle(FlatButtonStyle(prominent: false))
+				.controlSize(.small)
+			}
 		}
 		.padding(.vertical, 12)
 		.padding(.horizontal, 16)

--- a/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
@@ -1,0 +1,35 @@
+//
+//  AccountRow.swift
+//  Swiftcord
+//
+//  Created by Vincent Kwok on 3/9/22.
+//
+
+import SwiftUI
+
+struct AccountRow: View {
+	let avatarURL: URL
+	let username: String
+	let discriminator: String
+	let isCurrent: Bool
+
+	var body: some View {
+		HStack(spacing: 8) {
+			BetterImageView(url: avatarURL)
+				.clipShape(Circle())
+				.frame(width: 40, height: 40)
+			VStack(alignment: .leading) {
+				Text(verbatim: username).font(.title3)
+				+ Text("#\(discriminator)").foregroundColor(.secondary)
+				if isCurrent {
+					Text("Active account")
+						.font(.headline)
+						.foregroundColor(.green)
+				}
+			}
+			Spacer()
+		}
+		.padding(.vertical, 12)
+		.padding(.horizontal, 16)
+	}
+}

--- a/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
@@ -73,6 +73,7 @@ struct AccountRow: View {
 					if switcher.accounts.isEmpty {
 						gateway.disconnect()
 						state.attemptLogin = true
+						state.loadingState = .initial
 					} else if isCurrent {
 						switchAccount() // Switch to the next available account
 					}

--- a/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountRow.swift
@@ -79,7 +79,8 @@ struct AccountRow: View {
 					}
 				}
 			} label: {
-				Label("settings.user.logOut", systemImage: "rectangle.portrait.and.arrow.right")
+				Image(systemName: "rectangle.portrait.and.arrow.right")
+				Text("settings.user.logOut")
 			}
 		}
 	}

--- a/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
@@ -130,6 +130,16 @@ class AccountSwitcher: NSObject, ObservableObject {
 			accounts.insert(.init(user: user), at: 0)
 			inconsistency = true
 		}
+		let curUserIdx = accounts.firstIndex { $0.id == user.id }! // There will always be an entry for the current user
+		// Ensure meta for current user is updated
+		if accounts[curUserIdx].name != user.username ||
+		    accounts[curUserIdx].discrim != user.discriminator ||
+			accounts[curUserIdx].avatar != user.avatarURL(size: 80) {
+			AccountSwitcher.log.info("User meta for current user is outdated, it will be updated")
+			accounts[curUserIdx] = AccountMeta(user: user)
+			inconsistency = true
+		}
+
 		// Check for duplicates and remove them if any
 		var accountIDs: [Snowflake] = []
 		for (idx, account) in accounts.enumerated() {

--- a/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
@@ -13,7 +13,10 @@ class AccountSwitcher: NSObject, ObservableObject {
 	@Published var accounts: [AccountMeta] = []
 
 	static let META_KEY = "accountsMeta"
+	static let ACTIVE_KEY = "activeAcct"
 	static let log = Logger(category: "AccountSwitcher")
+
+	private var pendingToken: String?
 
 	func loadAccounts() {
 		guard let dec = try? JSONDecoder().decode(
@@ -28,13 +31,29 @@ class AccountSwitcher: NSObject, ObservableObject {
 		UserDefaults.standard.setValue(try? JSONEncoder().encode(accounts), forKey: AccountSwitcher.META_KEY)
 	}
 
+	func saveToken(for id: Snowflake, token: String) {
+		Keychain.save(key: "\(SwiftcordApp.tokenKeychainKey).\(id)", data: token)
+	}
+
+	func setPendingToken(token: String) {
+		pendingToken = token
+	}
+	func setActiveAccount(id: Snowflake) {
+		// ID is always assumed to be correct
+		UserDefaults.standard.set(id, forKey: AccountSwitcher.ACTIVE_KEY)
+	}
+
+	// Multiple sanity checks ensure account meta is valid, if not, repair is attempted
 	func getActiveToken() -> String? {
 		// If a token is found in the old keychain key, return that to allow logging in
 		if let oldToken = Keychain.load(key: SwiftcordApp.tokenKeychainKey) {
 			AccountSwitcher.log.info("Found token in old key! Logging in with this token...")
 			return oldToken
 		}
-		guard let activeID = accounts.first?.id else { return nil } // Account not signed in
+		let storedActiveID = UserDefaults.standard.string(forKey: AccountSwitcher.ACTIVE_KEY)
+		guard let activeID = storedActiveID != nil && accounts.contains(where: { $0.id == storedActiveID })
+			? storedActiveID
+			: accounts.first?.id else { return nil } // Account not signed in
 		guard let token = Keychain.load(key: "\(SwiftcordApp.tokenKeychainKey).\(activeID)") else {
 			// Something is wrong too
 			AccountSwitcher.log.error("Account meta exists for account ID \(activeID), but token was not found in keychain!")
@@ -48,8 +67,13 @@ class AccountSwitcher: NSObject, ObservableObject {
 		// Migrate from old keychain key to new keys
 		if let oldToken = Keychain.load(key: SwiftcordApp.tokenKeychainKey) {
 			Keychain.remove(key: SwiftcordApp.tokenKeychainKey)
-			Keychain.save(key: "\(SwiftcordApp.tokenKeychainKey).\(user.id)", data: oldToken)
+			saveToken(for: user.id, token: oldToken)
 			AccountSwitcher.log.info("Migrated old token to new keychain key format")
+		}
+
+		// If there's a token pending to be saved, save it under the current user ID
+		if let newToken = pendingToken {
+			saveToken(for: user.id, token: newToken)
 		}
 
 		var inconsistency = false

--- a/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
@@ -85,6 +85,7 @@ class AccountSwitcher: NSObject, ObservableObject {
 	func setActiveAccount(id: Snowflake) {
 		// ID is always assumed to be correct
 		UserDefaults.standard.set(id, forKey: AccountSwitcher.ACTIVE_KEY)
+		AccountSwitcher.clearAccountSpecificPrefKeys() // Clear account specific UserDefault keys
 	}
 
 	// Multiple sanity checks ensure account meta is valid, if not, repair is attempted

--- a/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 import DiscordKitCommon
+import os
 
 class AccountSwitcher: NSObject, ObservableObject {
 	@Published var accounts: [AccountMeta] = []
 
 	static let META_KEY = "accountsMeta"
+	static let log = Logger(category: "AccountSwitcher")
 
 	func loadAccounts() {
 		guard let dec = try? JSONDecoder().decode(
@@ -26,9 +28,50 @@ class AccountSwitcher: NSObject, ObservableObject {
 		UserDefaults.standard.setValue(try? JSONEncoder().encode(accounts), forKey: AccountSwitcher.META_KEY)
 	}
 
+	func getActiveToken() -> String? {
+		// If a token is found in the old keychain key, return that to allow logging in
+		if let oldToken = Keychain.load(key: SwiftcordApp.tokenKeychainKey) {
+			AccountSwitcher.log.info("Found token in old key! Logging in with this token...")
+			return oldToken
+		}
+		guard let activeID = accounts.first?.id else { return nil } // Account not signed in
+		guard let token = Keychain.load(key: "\(SwiftcordApp.tokenKeychainKey).\(activeID)") else {
+			// Something is wrong too
+			AccountSwitcher.log.error("Account meta exists for account ID \(activeID), but token was not found in keychain!")
+			accounts.removeAll { acct in acct.id == activeID }
+			return nil
+		}
+		return token
+	}
+
 	func onSignedIn(with user: CurrentUser) {
+		// Migrate from old keychain key to new keys
+		if let oldToken = Keychain.load(key: SwiftcordApp.tokenKeychainKey) {
+			Keychain.remove(key: SwiftcordApp.tokenKeychainKey)
+			Keychain.save(key: "\(SwiftcordApp.tokenKeychainKey).\(user.id)", data: oldToken)
+			AccountSwitcher.log.info("Migrated old token to new keychain key format")
+		}
+
+		var inconsistency = false
+		// Ensure the current account exists, if not add it
 		if !accounts.contains(where: { $0.id == user.id }) {
 			accounts.insert(.init(user: user), at: 0)
+			inconsistency = true
+		}
+		// Check for duplicates and remove them if any
+		var accountIDs: [Snowflake] = []
+		for (idx, account) in accounts.enumerated() {
+			if accountIDs.contains(account.id) ||
+			    Keychain.load(key: "\(SwiftcordApp.tokenKeychainKey).\(account.id)") == nil {
+				// Invalid account
+				accounts.remove(at: idx)
+				inconsistency = true
+				AccountSwitcher.log.warning("Found dupe, or no token found in keychain for account \(account.id)")
+			} else { accountIDs.append(account.id) }
+		}
+
+		if inconsistency {
+			AccountSwitcher.log.warning("Fixing account meta inconsistencies")
 			writeAccounts()
 		}
 	}
@@ -36,6 +79,5 @@ class AccountSwitcher: NSObject, ObservableObject {
 	override init() {
 		super.init()
 		loadAccounts()
-		//UserDefaults.standard.addObserver(self, forKeyPath: "accountsMeta", options: NSKeyValueObservingOptions.new, context: nil)
 	}
 }

--- a/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/AccountSwitcher.swift
@@ -1,0 +1,41 @@
+//
+//  AccountSwitcher.swift
+//  Swiftcord
+//
+//  Created by Vincent Kwok on 4/9/22.
+//
+
+import Foundation
+import DiscordKitCommon
+
+class AccountSwitcher: NSObject, ObservableObject {
+	@Published var accounts: [AccountMeta] = []
+
+	static let META_KEY = "accountsMeta"
+
+	func loadAccounts() {
+		guard let dec = try? JSONDecoder().decode(
+			[AccountMeta].self,
+			from: UserDefaults.standard.data(forKey: AccountSwitcher.META_KEY) ?? Data())
+		else {
+			return
+		}
+		accounts = dec
+	}
+	func writeAccounts() {
+		UserDefaults.standard.setValue(try? JSONEncoder().encode(accounts), forKey: AccountSwitcher.META_KEY)
+	}
+
+	func onSignedIn(with user: CurrentUser) {
+		if !accounts.contains(where: { $0.id == user.id }) {
+			accounts.insert(.init(user: user), at: 0)
+			writeAccounts()
+		}
+	}
+
+	override init() {
+		super.init()
+		loadAccounts()
+		//UserDefaults.standard.addObserver(self, forKeyPath: "accountsMeta", options: NSKeyValueObservingOptions.new, context: nil)
+	}
+}

--- a/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
@@ -1,0 +1,48 @@
+//
+//  CurrentUserFooter+.swift
+//  Swiftcord
+//
+//  Created by Vincent Kwok on 3/9/22.
+//
+
+import SwiftUI
+
+extension CurrentUserFooter {
+	@ViewBuilder func accountSwitcher() -> some View {
+		DialogView(title: "Manage Accounts", description: "Switch accounts, sign in, sign out, go wild.") {
+			Button { switcherPresented = false } label: {
+				Text("action.close")
+			}
+			.buttonStyle(.plain)
+			Spacer()
+			Button {
+				switcherPresented = false
+				loginPresented = true
+			} label: {
+				Text("Add an account")
+			}
+			.buttonStyle(FlatButtonStyle(prominent: false))
+			.controlSize(.small)
+		} content: {
+			GroupBox {
+				ScrollView {
+					LazyVStack(spacing: 0) {
+						ForEach(accounts, id: \.id) { account in
+							AccountRow(
+								avatarURL: user.avatarURL(size: 80),
+								username: user.username,
+								discriminator: user.discriminator,
+								isCurrent: account.id == user.id
+							)
+							if account != accounts.last {
+								Divider().padding(.horizontal, 16)
+							}
+						}
+					}
+				}
+				.frame(maxHeight: 240)
+				.padding(-4)
+			}
+		}
+	}
+}

--- a/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
@@ -15,6 +15,38 @@ extension CurrentUserFooter {
 			}
 			.buttonStyle(.plain)
 			Spacer()
+
+			Button {
+				switcherHelpPresented = true
+			} label: {
+				Image(systemName: "questionmark.circle").font(.system(size: 24))
+			}
+			.buttonStyle(.plain)
+			.contentShape(Circle())
+			.padding(.trailing, 4)
+			.popover(isPresented: $switcherHelpPresented, arrowEdge: .bottom) {
+				VStack(alignment: .leading) {
+					Text("About Account Switcher").font(.title2)
+					Text("Add, switch to or log out of accounts")
+						.lineLimit(nil)
+					Divider()
+
+					Group {
+						Text("Adding Accounts").font(.headline)
+						Text("You can as many accounts as you'd like")
+						Text("Account tokens are securely stored in your keychain")
+							.padding(.bottom, 4)
+						Text("Switching Accounts").font(.headline)
+						Text("Simply use the 'Switch' buttons to switch accounts")
+							.padding(.bottom, 4)
+						Text("Logging Out of Accounts").font(.headline)
+						Text("Right click on any account to sign out of it")
+					}
+				}
+				.padding()
+				.frame(maxWidth: 400)
+			}
+
 			Button {
 				switcherPresented = false
 				loginPresented = true

--- a/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
@@ -21,7 +21,7 @@ extension CurrentUserFooter {
 			} label: {
 				Text("Add an account")
 			}
-			.buttonStyle(FlatButtonStyle(prominent: false))
+			.buttonStyle(FlatButtonStyle())
 			.controlSize(.small)
 		} content: {
 			GroupBox {
@@ -29,10 +29,9 @@ extension CurrentUserFooter {
 					LazyVStack(spacing: 0) {
 						ForEach(switcher.accounts, id: \.id) { account in
 							AccountRow(
-								avatarURL: user.avatarURL(size: 80),
-								username: user.username,
-								discriminator: user.discriminator,
-								isCurrent: account.id == user.id
+								meta: account,
+								isCurrent: account.id == user.id,
+								switcherPresented: $switcherPresented
 							)
 							if account != switcher.accounts.last {
 								Divider().padding(.horizontal, 16)

--- a/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
+++ b/Swiftcord/Views/User/AccountSwitcher/CurrentUserFooter+.swift
@@ -27,14 +27,14 @@ extension CurrentUserFooter {
 			GroupBox {
 				ScrollView {
 					LazyVStack(spacing: 0) {
-						ForEach(accounts, id: \.id) { account in
+						ForEach(switcher.accounts, id: \.id) { account in
 							AccountRow(
 								avatarURL: user.avatarURL(size: 80),
 								username: user.username,
 								discriminator: user.discriminator,
 								isCurrent: account.id == user.id
 							)
-							if account != accounts.last {
+							if account != switcher.accounts.last {
 								Divider().padding(.horizontal, 16)
 							}
 						}

--- a/Swiftcord/Views/User/CurrentUserFooter.swift
+++ b/Swiftcord/Views/User/CurrentUserFooter.swift
@@ -56,8 +56,6 @@ struct CurrentUserFooter: View {
 			.background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
 		}
 		.buttonStyle(.plain)
-		// .onAppear { parseAccounts() }
-		// .onChange(of: accountMeta) { _ in parseAccounts() }
 		.popover(isPresented: $userPopoverPresented) {
 			MiniUserProfileView(user: User(from: user), profile: .constant(UserProfile(
 				connected_accounts: [],

--- a/Swiftcord/Views/User/CurrentUserFooter.swift
+++ b/Swiftcord/Views/User/CurrentUserFooter.swift
@@ -17,19 +17,7 @@ struct CurrentUserFooter: View {
 	@State var switcherPresented = false
 	@State var loginPresented = false
 
-	@AppStorage("accountsMeta") var accountMeta = Data()
-	@State var accounts: [AccountMeta] = []
-
-	private func parseAccounts() {
-		guard let dec = try? JSONDecoder().decode([AccountMeta].self, from: accountMeta) else {
-			accounts = [.init(user: user)]
-			return
-		}
-		accounts = dec
-		if !accounts.contains(where: { $0.id == user.id }) {
-			accounts.insert(.init(user: user), at: 0)
-		}
-	}
+	@EnvironmentObject var switcher: AccountSwitcher
 
     var body: some View {
 		Button {
@@ -68,8 +56,8 @@ struct CurrentUserFooter: View {
 			.background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
 		}
 		.buttonStyle(.plain)
-		.onAppear { parseAccounts() }
-		.onChange(of: accountMeta) { _ in parseAccounts() }
+		// .onAppear { parseAccounts() }
+		// .onChange(of: accountMeta) { _ in parseAccounts() }
 		.popover(isPresented: $userPopoverPresented) {
 			MiniUserProfileView(user: User(from: user), profile: .constant(UserProfile(
 				connected_accounts: [],

--- a/Swiftcord/Views/User/CurrentUserFooter.swift
+++ b/Swiftcord/Views/User/CurrentUserFooter.swift
@@ -24,6 +24,10 @@ struct CurrentUserFooter: View {
     var body: some View {
 		Button {
 			userPopoverPresented = true
+			AnalyticsWrapper.event(type: .openPopout, properties: [
+				"type": "User Status Menu",
+				"other_user_id": user.id
+			])
 		} label: {
 			HStack(spacing: 8) {
 				BetterImageView(url: user.avatarURL())
@@ -66,6 +70,7 @@ struct CurrentUserFooter: View {
 				if !(user.bio?.isEmpty ?? true) { Divider() }
 				Button {
 					switcherPresented = true
+					AnalyticsWrapper.event(type: .impressionAccountSwitcher)
 				} label: {
 					Label("Switch Accounts", systemImage: "arrow.left.arrow.right").frame(maxWidth: .infinity)
 				}.buttonStyle(FlatButtonStyle(outlined: true))
@@ -90,12 +95,13 @@ struct CurrentUserFooter: View {
 					}
 					.buttonStyle(.plain)
 					Button { showQR.toggle() } label: {
-						Image(systemName: "qrcode")
+						Image(systemName: showQR ? "keyboard" : "qrcode")
 							.contentShape(Rectangle())
-							.font(.system(size: 24, weight: .bold))
+							.font(.system(size: 24, weight: .medium))
 							.opacity(0.75)
 					}
 					.buttonStyle(.plain)
+					.frame(width: 24)
 				}.padding(16)
 			}
 		}

--- a/Swiftcord/Views/User/CurrentUserFooter.swift
+++ b/Swiftcord/Views/User/CurrentUserFooter.swift
@@ -13,38 +13,95 @@ import DiscordKitCommon
 struct CurrentUserFooter: View {
     let user: CurrentUser
 
+	@State private var userPopoverPresented = false
+	@State private var switcherPresented = false
+	@State private var loginPresented = false
+
     var body: some View {
-        HStack(spacing: 8) {
-			BetterImageView(url: user.avatarURL())
-				.frame(width: 32, height: 32)
-				.clipShape(Circle())
-				.padding(.leading, 8)
+		Button {
+			userPopoverPresented = true
+		} label: {
+			HStack(spacing: 8) {
+				BetterImageView(url: user.avatarURL())
+					.frame(width: 32, height: 32)
+					.clipShape(Circle())
+					.padding(.leading, 8)
 
-            VStack(alignment: .leading, spacing: 0) {
-                Text(user.username).font(.headline)
-                Text("#" + user.discriminator).font(.system(size: 12)).opacity(0.75)
-            }
-			Spacer()
+				VStack(alignment: .leading, spacing: 0) {
+					Text(user.username).font(.headline)
+					Text("#" + user.discriminator).font(.system(size: 12)).opacity(0.75)
+				}
+				Spacer()
 
-			// The hidden selector for opening the preferences window
-			// is probably removed in macOS 13. Should check if this
-			// is still broken once macOS 13 is stable.
-			if #available(macOS 13.0, *) {
-				EmptyView()
-			} else {
-				Button(action: {
-					NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
-				}, label: {
-					Image(systemName: "gearshape.fill")
-						.font(.system(size: 18))
-						.opacity(0.75)
-				})
-				.buttonStyle(.plain)
-				.padding(.trailing, 14)
+				// The hidden selector for opening the preferences window
+				// is probably removed in macOS 13. Should check if this
+				// is still broken once macOS 13 is stable.
+				if #available(macOS 13.0, *) {
+					EmptyView()
+				} else {
+					Button(action: {
+						NSApp.sendAction(Selector(("showPreferencesWindow:")), to: nil, from: nil)
+					}, label: {
+						Image(systemName: "gearshape.fill")
+							.font(.system(size: 18))
+							.opacity(0.75)
+					})
+					.buttonStyle(.plain)
+					.padding(.trailing, 14)
+				}
 			}
-        }
-        .frame(height: 52)
-		.background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+			.frame(height: 52)
+			.background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+		}
+		.buttonStyle(.plain)
+		.popover(isPresented: $userPopoverPresented) {
+			MiniUserProfileView(user: User(from: user), profile: .constant(UserProfile(
+				connected_accounts: [],
+				user: User(from: user)
+			))) {
+				Divider()
+				Button {
+					switcherPresented = true
+				} label: {
+					Label("Switch Accounts", systemImage: "arrow.left.arrow.right").frame(maxWidth: .infinity)
+				}.buttonStyle(FlatButtonStyle(prominent: false, outlined: true))
+			}
+		}
+		.sheet(isPresented: $switcherPresented) {
+			DialogView(title: "Manage Accounts", description: "Switch accounts, sign in, sign out, go wild.") {
+				Button { switcherPresented = false } label: {
+					Text("action.close")
+				}
+				.buttonStyle(.plain)
+				Spacer()
+				Button {
+					switcherPresented = false
+					loginPresented = true
+				} label: {
+					Text("Add an account")
+				}
+				.buttonStyle(FlatButtonStyle(prominent: false))
+				.controlSize(.small)
+			} content: {
+				Text("Lmao")
+			}
+		}
+		.sheet(isPresented: $loginPresented) {
+			ZStack(alignment: .topTrailing) {
+				LoginView(shrink: true)
+					.frame(width: 450, height: 600)
+				Button {
+					loginPresented = false
+				} label: {
+					Image(systemName: "xmark")
+						.contentShape(Circle())
+						.font(.system(size: 24, weight: .bold))
+						.opacity(0.75)
+				}
+				.buttonStyle(.plain)
+				.padding(16)
+			}
+		}
     }
 }
 

--- a/Swiftcord/Views/User/CurrentUserFooter.swift
+++ b/Swiftcord/Views/User/CurrentUserFooter.swift
@@ -16,6 +16,8 @@ struct CurrentUserFooter: View {
 	@State var userPopoverPresented = false
 	@State var switcherPresented = false
 	@State var loginPresented = false
+	@State var showQR = false
+	@State var switcherHelpPresented = false
 
 	@EnvironmentObject var switcher: AccountSwitcher
 
@@ -61,7 +63,7 @@ struct CurrentUserFooter: View {
 				connected_accounts: [],
 				user: User(from: user)
 			))) {
-				Divider()
+				if !(user.bio?.isEmpty ?? true) { Divider() }
 				Button {
 					switcherPresented = true
 				} label: {
@@ -74,18 +76,27 @@ struct CurrentUserFooter: View {
 		}
 		.sheet(isPresented: $loginPresented) {
 			ZStack(alignment: .topTrailing) {
-				LoginView(shrink: true)
-					.frame(width: 450, height: 600)
-				Button {
+				LoginView(shrink: true, showQR: showQR) { // Log in callback
 					loginPresented = false
-				} label: {
-					Image(systemName: "xmark")
-						.contentShape(Circle())
-						.font(.system(size: 24, weight: .bold))
-						.opacity(0.75)
 				}
-				.buttonStyle(.plain)
-				.padding(16)
+				.frame(width: 450, height: 600)
+
+				VStack(spacing: 16) {
+					Button { loginPresented = false } label: {
+						Image(systemName: "xmark")
+							.contentShape(Circle())
+							.font(.system(size: 24, weight: .bold))
+							.opacity(0.75)
+					}
+					.buttonStyle(.plain)
+					Button { showQR.toggle() } label: {
+						Image(systemName: "qrcode")
+							.contentShape(Rectangle())
+							.font(.system(size: 24, weight: .bold))
+							.opacity(0.75)
+					}
+					.buttonStyle(.plain)
+				}.padding(16)
 			}
 		}
     }


### PR DESCRIPTION
Ever envied your cool friends using Discord's built in account switcher for their split personalities? Fret not, for Swiftcord has got you covered! With this PR, you can now add as many accounts as you want, and gone are the days when you're bounded by the shackles of the limited Discord client!

Not only can you add as many accounts as you'd wish, all account tokens are always stored securely in the Keychain, so say goodbye to token grabbers! The token stored in the keychain by older releases will automatically be migrated over to the new scheme of token storage, and you will seamlessly be able to add multiple accounts now! 

## Checklist
- [x] UI
- [x] Token storage, handle logging in more than one account
- [x] Handle logging out more than one account
- [x] Token migration

## Screenshots
**Popup**
<img width="362" alt="Screenshot 2022-09-04 at 5 41 55 PM" src="https://user-images.githubusercontent.com/64193267/188307390-f49dca6a-6277-4bdc-a21a-cd52454522ac.png">

**Accounts dialog**
<img width="940" alt="Screenshot 2022-09-04 at 5 42 57 PM" src="https://user-images.githubusercontent.com/64193267/188307418-2e8ccf15-0661-41af-96e6-bcb7d0f28adf.png">
**Mini sign in window to sign into new accounts, with button to show QR**
<img width="1100" alt="Screenshot 2022-09-04 at 10 48 05 PM" src="https://user-images.githubusercontent.com/64193267/188319518-94595716-de3e-4c6c-910c-4cd131a4b320.png">

**QR-only sign in**
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/64193267/188319485-5d611611-3b84-4f38-80dd-0bcfe2cef068.png">


## Future enhancements:
* Different account per window
* Something else?