### PR TITLE
Add folder display capability

### DIFF
--- a/Swiftcord.xcodeproj/project.pbxproj
+++ b/Swiftcord.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		368B6731287A211F00E37B33 /* HorizontalDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4350032879C38C001DEC81 /* HorizontalDividerView.swift */; };
 		36BC29F3285C162500A8B316 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 36BC29F2285C162500A8B316 /* Credits.rtf */; };
 		900F6DA1284A1C0C000B6D29 /* GeneratedBuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900F6DA0284A1C0C000B6D29 /* GeneratedBuildSettings.swift */; };
+		9FCE7B1D28C7140100213A3F /* ServerFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCE7B1C28C7140100213A3F /* ServerFolder.swift */; };
+		9FCE7B1E28C7140100213A3F /* ServerFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCE7B1C28C7140100213A3F /* ServerFolder.swift */; };
 		DA03DA3F284F1E9200257790 /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA03DA3E284F1E9200257790 /* Keychain.swift */; };
 		DA2384A127CB9714009E15E0 /* Font+.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2384A027CB9714009E15E0 /* Font+.swift */; };
 		DA2384BA27CBC2CE009E15E0 /* GintoBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = DA2384B827CBC2CE009E15E0 /* GintoBold.otf */; };
@@ -250,6 +252,7 @@
 		900F6D9F284A1AE6000B6D29 /* Project Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project Release.xcconfig"; sourceTree = "<group>"; };
 		900F6DA0284A1C0C000B6D29 /* GeneratedBuildSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedBuildSettings.swift; sourceTree = "<group>"; };
 		90F77AAA284C87E900166BF3 /* AppCenter.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppCenter.xcconfig; sourceTree = "<group>"; };
+		9FCE7B1C28C7140100213A3F /* ServerFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerFolder.swift; sourceTree = "<group>"; usesTabs = 0; };
 		DA03DA3E284F1E9200257790 /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		DA23843827CB934D009E15E0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DA2384A027CB9714009E15E0 /* Font+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+.swift"; sourceTree = "<group>"; };
@@ -622,6 +625,7 @@
 				DA4350012879BFCA001DEC81 /* ServerJoinView.swift */,
 				DA57F44328056718001DC46E /* ChannelList.swift */,
 				DA57F44528065209001DC46E /* ChannelButton.swift */,
+				9FCE7B1C28C7140100213A3F /* ServerFolder.swift */,
 			);
 			path = Server;
 			sourceTree = "<group>";
@@ -985,6 +989,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9FCE7B1E28C7140100213A3F /* ServerFolder.swift in Sources */,
 				DAB1E48828A50D3600645FCD /* DefaultMessageView.swift in Sources */,
 				3642993E286801C900483D0A /* OnboardingView.swift in Sources */,
 				3642993F286801C900483D0A /* String+.swift in Sources */,
@@ -1151,6 +1156,7 @@
 				DA2BD30E284CCC9800EBB8D6 /* Text+.swift in Sources */,
 				DAB1E46C28A10BB100645FCD /* BetterImageView.swift in Sources */,
 				DAA57E242892270800C9A931 /* SwiftyGifNSView.swift in Sources */,
+				9FCE7B1D28C7140100213A3F /* ServerFolder.swift in Sources */,
 				DA2BD30C284CB38B00EBB8D6 /* AppSettingsAppearanceView.swift in Sources */,
 				DAAFB5C3282AA5C700807B54 /* MessageInfoBarView.swift in Sources */,
 				DA32EF5027C8D7E000A9ED72 /* Message+.swift in Sources */,

--- a/Swiftcord/Views/ContentView.swift
+++ b/Swiftcord/Views/ContentView.swift
@@ -70,7 +70,7 @@ struct ContentView: View {
 			state.selectedGuildID = lGID
 		} else { state.selectedGuildID = "@me" }
 	}
-	
+
     private var serverListItems: [ServerListItem] {
         let unsortedGuilds = gateway.cache.guilds.values.filter({ guild in
             !(gateway.cache.userSettings?.guild_folders?.contains(where: { folder in
@@ -109,7 +109,7 @@ struct ContentView: View {
                     ).padding(.top, 4)
 
 					HorizontalDividerView().frame(width: 32)
-                    
+
                     ForEach(self.serverListItems) { item in
                         switch item {
                         case .guild(let guild):
@@ -238,10 +238,10 @@ struct ContentView: View {
 			ServerJoinView(presented: $presentingAddServer)
 		}
 	}
-    
+
     private enum ServerListItem: Identifiable {
         case guild(Guild), guildFolder(ServerFolder.GuildFolder)
-        
+
         var id: String {
             switch self {
             case .guild(let guild):

--- a/Swiftcord/Views/Server/ServerFolder.swift
+++ b/Swiftcord/Views/Server/ServerFolder.swift
@@ -171,7 +171,7 @@ struct MiniServerThumb: View {
                         .frame(width: 16, height: 16)
                         .cornerRadius(8)
                 } else {
-                    BetterImageView(url: iconURL)
+                    BetterImageView(url: iconURL, imageModifier: { $0.antialiased(true) })
                         .frame(width: 16, height: 16)
                         .cornerRadius(8)
                 }

--- a/Swiftcord/Views/Server/ServerFolder.swift
+++ b/Swiftcord/Views/Server/ServerFolder.swift
@@ -12,7 +12,7 @@ import DiscordKitCommon
 struct ServerFolder: View {
     let folder: GuildFolder
     @State private var hovered = false
-    @State var open = true
+    @State var open = false
     @Binding var selectedGuildID: Snowflake?
     @State var loadingGuildID: Snowflake?
 
@@ -54,7 +54,16 @@ struct ServerFolder: View {
                     .mask(backgroundCapsuleMaskView)
 
                 VStack {
-                    Button("", action: { self.open.toggle() })
+                    Button("") {
+                        open.toggle()
+                        if open {
+                            UserDefaults.standard.setValue(true, forKey: "folders.\(folder.id).open")
+                        } else {
+                            UserDefaults.standard.removeObject(forKey: "folders.\(folder.id).open")
+                        }
+                    }.onAppear {
+                        open = UserDefaults.standard.bool(forKey: "folders.\(folder.id).open")
+                    }
                     .buttonStyle(
                         // Server folder open/close toggle
                         ServerFolderButtonStyle(

--- a/Swiftcord/Views/Server/ServerFolder.swift
+++ b/Swiftcord/Views/Server/ServerFolder.swift
@@ -1,0 +1,194 @@
+//
+//  ServerFolder.swift
+//  Swiftcord
+//
+//  Created by Teddy Gaillard on 9/5/22.
+//
+
+import SwiftUI
+import DiscordKitCore
+import DiscordKitCommon
+
+struct ServerFolder: View {
+    let folder: GuildFolder
+    @State private var hovered = false
+    @State var open = true
+    @Binding var selectedGuildID: Snowflake?
+    @State var loadingGuildID: Snowflake?
+    
+    // This creates an inverse mask of the folder open/close button,
+    // so the background capsule isn't visible behind the button
+    var backgroundCapsuleMaskView: some View {
+        HStack {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(.black)
+                .frame(width: 48, height: 48, alignment: .top)
+        }
+            .frame(width: 48, height: open ? CGFloat(56 * folder.guilds.count + 48) : 48, alignment: .top)
+        .background(.white)
+        .compositingGroup()
+        .luminanceToAlpha()
+    }
+    
+    var folderIndicator: some View {
+        HStack(alignment: .center) {
+            Capsule()
+                .scale(hovered && !open ? 1 : 0)
+                .fill(Color(nsColor: .labelColor))
+                .frame(width: 8, height: hovered ? 20 : 8)
+                .animation(Self.capsuleAnimation, value: hovered && !open)
+        }
+        .frame(height: 48)
+    }
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            folderIndicator
+            Spacer()
+            
+            ZStack {
+                // Background tint behind servers in folder
+                Capsule()
+                    .fill(.gray.opacity(0.15))
+                    .frame(width: 48)
+                    .mask(backgroundCapsuleMaskView)
+                
+                VStack {
+                    Button("", action: { self.open.toggle() })
+                    .buttonStyle(
+                        // Server folder open/close toggle
+                        ServerFolderButtonStyle(
+                            open: open,
+                            color: folder.color,
+                            guilds: Array(folder.guilds.prefix(4)),
+                            hovered: $hovered
+                        )
+                    )
+                    .popover(isPresented: $hovered, attachmentAnchor: .point(.trailing), arrowEdge: .trailing) {
+                        Text(folder.name).padding(8)
+                            // Prevent popover from blocking clicks to other views
+                            .interactiveDismissDisabled()
+                    }
+
+                    if open {
+                        ForEach(folder.guilds) { [self] guild in
+                            ServerButton(
+                                selected: selectedGuildID == guild.id || loadingGuildID == guild.id,
+                                name: guild.name,
+                                serverIconURL: guild.icon != nil ? "\(GatewayConfig.default.cdnURL)icons/\(guild.id)/\(guild.icon!).webp?size=240" : nil,
+                                isLoading: loadingGuildID == guild.id,
+                                onSelect: { selectedGuildID = guild.id }
+                            )
+                            // Prevent server buttons from "fading in" during transition
+                            .transition(.identity)
+                        }
+                    }
+                }
+                .frame(width: 48, height: open ? CGFloat(56 * folder.guilds.count + 48) : 48, alignment: .top)
+            }
+            .frame(width: 48)
+            .padding(.trailing, 8)
+            
+            Spacer()
+        }
+        .frame(width: 72)
+    }
+    
+    static let capsuleAnimation = Animation.interpolatingSpring(stiffness: 500, damping: 30)
+    
+    struct GuildFolder: Identifiable {
+        let name: String
+        let guilds: [Guild]
+        let color: Color
+        
+        var id: Snowflake {
+            self.guilds.first?.id ?? ""
+        }
+    }
+}
+
+struct ServerFolderButtonStyle: ButtonStyle {
+    let open: Bool
+    let color: Color
+    let guilds: [Guild]
+    var filledGuilds: [Guild?] {
+        guilds + [Guild?](repeating: nil, count: 4 - guilds.count)
+    }
+    @Binding var hovered: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        ZStack {
+            if open {
+                Image(systemName: "folder.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(color)
+                    .transition(.asymmetric(insertion: .move(edge: .top), removal: .move(edge: .bottom)))
+            } else {
+                VStack(spacing: 4) {
+                    HStack(spacing: 4) {
+                        MiniServerThumb(guild: filledGuilds[0])
+                        MiniServerThumb(guild: filledGuilds[1])
+                    }
+                    HStack(spacing: 4) {
+                        MiniServerThumb(guild: filledGuilds[2])
+                        MiniServerThumb(guild: filledGuilds[3])
+                    }
+                }
+                .foregroundColor(hovered ? .white : Color(nsColor: .labelColor))
+                .transition(.asymmetric(insertion: .move(edge: .bottom), removal: .move(edge: .top)))
+            }
+        }
+        .frame(width: 48, height: 48)
+        .background(
+            open
+            ? .gray.opacity(hovered ? 0.25 : 0.15)
+            : color.opacity(hovered ? 0.5 : 0.4)
+        )
+        .mask {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+        }
+        .clipped()
+        .offset(y: configuration.isPressed ? 1 : 0)
+        .animation(.none, value: configuration.isPressed)
+        .animation(.interpolatingSpring(stiffness: 500, damping: 30), value: hovered)
+        .onHover { hover in hovered = hover }
+        .animation(.linear(duration: 0.1), value: open)
+    }
+}
+
+struct MiniServerThumb: View {
+    let guild: Guild?
+    
+    var body: some View {
+        if let guild = guild {
+            if let serverIconPath = guild.icon, let iconURL = URL(string: "\(GatewayConfig.default.cdnURL)icons/\(guild.id)/\(serverIconPath).webp?size=240") {
+                if iconURL.isAnimatable {
+                    SwiftyGifView(
+                        url: iconURL.modifyingPathExtension("gif"),
+                        resetWhenNotAnimating: true
+                    )
+                        .transition(.customOpacity)
+                        .frame(width: 16, height: 16)
+                        .cornerRadius(8)
+                } else {
+                    BetterImageView(url: iconURL)
+                        .frame(width: 16, height: 16)
+                        .cornerRadius(8)
+                }
+            } else {
+                let iconName = guild.name.split(separator: " ").map({ $0.prefix(1) }).joined(separator: "")
+                Text(iconName)
+                    .font(.system(size: iconName.count < 7 ? CGFloat((6 - iconName.count)*2) : 10))
+                    .foregroundColor(.white)
+                    .lineLimit(1)
+                    .frame(width: 16, height: 16)
+                    .background(.gray.opacity(0.15))
+                    .cornerRadius(8)
+            }
+        } else {
+            Rectangle()
+                .opacity(0)
+                .frame(width: 16, height: 16)
+        }
+    }
+}

--- a/Swiftcord/Views/Utils/BetterImageView.swift
+++ b/Swiftcord/Views/Utils/BetterImageView.swift
@@ -10,29 +10,37 @@ import CachedAsyncImage
 
 /// A much better base for remote images, has loading placeholders built in and sane default modifiers for the image
 struct BetterImageView<ErrorContent: View>: View {
-	let url: URL?
-	@ViewBuilder let customErrorView: ErrorContent
-
+    let url: URL?
+    let imageModifier: (Image) -> Image
+    @ViewBuilder let customErrorView: () -> ErrorContent
+    
     var body: some View {
-		CachedAsyncImage(url: url) { phase in
-			if let image = phase.image {
-				image
-					.resizable()
-					.scaledToFill()
-					.transition(.customOpacity)
-			} else if phase.error != nil {
-				customErrorView
-			} else {
-				Rectangle().fill(.gray.opacity(0.25)).transition(.customOpacity)
-			}
-		}
+        CachedAsyncImage(url: url) { phase in
+            if let image = phase.image {
+                imageModifier(image)
+                    .resizable()
+                    .scaledToFill()
+                    .transition(.customOpacity)
+            } else if phase.error != nil {
+                customErrorView()
+            } else {
+                Rectangle().fill(.gray.opacity(0.25)).transition(.customOpacity)
+            }
+        }
     }
 }
 
 extension BetterImageView where ErrorContent == EmptyView {
-	init(url: URL?) {
-		self.init(url: url) {
-			EmptyView()
-		}
-	}
+    init(url: URL?, imageModifier: @escaping (Image) -> Image = { $0 }) {
+        self.init(url: url, imageModifier: imageModifier, customErrorView: {
+            EmptyView()
+        })
+    }
+}
+
+extension BetterImageView {
+    // Allow trailing closure syntax
+    init(url: URL?, @ViewBuilder customErrorView: @escaping () -> ErrorContent) {
+        self.init(url: url, imageModifier: { $0 }, customErrorView: customErrorView)
+    }
 }

--- a/Swiftcord/Views/Utils/BetterImageView.swift
+++ b/Swiftcord/Views/Utils/BetterImageView.swift
@@ -13,7 +13,7 @@ struct BetterImageView<ErrorContent: View>: View {
     let url: URL?
     let imageModifier: (Image) -> Image
     @ViewBuilder let customErrorView: () -> ErrorContent
-    
+
     var body: some View {
         CachedAsyncImage(url: url) { phase in
             if let image = phase.image {


### PR DESCRIPTION
Pretty much what it sounds like. I matched the Discord UI very closely. Opportunities for future improvement/other notes:

-  Folders with only one server are displayed as single servers...the API is not very well structured in this area and I didn't find a way to differentiate between folders containing only one server and a server which isn't in a folder
-  Again, the API in this area is very unclear, so I'm not exactly whether ungrouped folders, which were never added to a group, but had their order rearranged, will display in the correct order. If they don't, they should just display above all of the folders. This is something that may be desirable to test later.
-  I created two new data structures, `ContentView.ServerListItem` and `ServerFolder.GuildFolder`. I didn't really know where to put these, since the project's current data model was unclear to me. This is something that could be rather painlessly fixed before merging.
-  I added popovers to display the names of folders. This causes serious choppiness while scrolling through large numbers of folders (blocking the animation thread?) but since that scenario is relatively uncommon, and there is no other way to view the name of the folder, I found the tradeoff acceptable. This could also be changed before merging.
-  I had to make some rather odd changes to get this project to build on my system (including commenting out `UserSettingsView.swift:35` and `LoadingView.swift:37`). I did my best to make sure none of these changes got committed (including changes to Swiftcord.pbxproj). Because of this, I also don't know for sure whether my changes will build properly on a CI server or anyone else's machine, though I suspect they should.
-  I wasn't able to get a good folder "drawer" opening/closing animation. The server icon previews and folder icon slides up and down as in vanilla Discord, but I wasn't able to get other servers to "move out of the way" smoothly, and they just ended up jumping to the correct position. This resulted in the animation looking half-baked, so I decided to remove it. Maybe someone could work some SwiftUI magic to get this fixed.
-  Animated mini-icons inside the folder preview always animate, not just on hover
-  The mini-icons inside the folder preview look *awful* on a low res screen, at least compared to vanilla Discord. I tried using SwiftUI's antialiasing (which is still explicitly enabled on those mini-icons), but it didn't really help
-  In order to do this, I made some modifications to `BetterImageView`, allowing a consumer to pass an `(Image) -> Image` closure to make modifications to the original image. This is backwards compatible (at least for all the existing usages in the codebase) and an additive change.

I'm happy to DM screen recordings of my UI, in case you don't want to build my changes. I just don't really want the names of all the servers I'm in out in the wild.