### PR TITLE
[Enhancement]: Ventura-style Settings overhaul

### DIFF
--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -100,14 +100,11 @@ struct SwiftcordApp: App {
 			}
 		}
 		.commands {
+		#if !APP_STORE
 			CommandGroup(after: .appInfo) {
-				#if !APP_STORE
 				CheckForUpdatesView(updaterViewModel: updaterViewModel)
-				#endif
-				if #available(macOS 13, *) {
-					SettingsCommands()
-				}
 			}
+			#endif
 
 			SidebarCommands()
 			NavigationCommands(state: state, gateway: gateway)
@@ -115,7 +112,7 @@ struct SwiftcordApp: App {
 		.windowStyle(.hiddenTitleBar)
 		.windowToolbarStyle(.unified)
 
-		WindowGroup(id: "settings") { // Identify the window group.
+		Settings {
 			SettingsView()
 				.environmentObject(gateway)
 				.environmentObject(state)
@@ -125,7 +122,18 @@ struct SwiftcordApp: App {
 					? .dark
 					: (selectedTheme == "light" ? .light : .none)
 				)
-		}.contentSizedWindowResizability()
+			.task {
+				// print("run")
+				let window = NSApp.windows.first { $0.identifier?.rawValue == "com_apple_SwiftUI_Settings_window" }!
+				window.toolbarStyle = .unified
+
+				let sidebaritem = "com.apple.SwiftUI.navigationSplitView.toggleSidebar"
+				let index = window.toolbar?.items.firstIndex { $0.itemIdentifier.rawValue == sidebaritem }
+				if let index {
+					window.toolbar?.removeItem(at: index)
+				}
+			}
+		}
 	}
 }
 

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -16,6 +16,16 @@ let appName = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String
 // MARK: Global Objects
 let restAPI = DiscordREST()
 
+fileprivate extension Scene {
+	func contentSizedWindowResizability() -> some Scene {
+		if #available(macOS 13.0, *) {
+			return self.windowResizability(.contentSize)
+		} else {
+			return self
+		}
+	}
+}
+
 @main
 struct SwiftcordApp: App {
 	@NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
@@ -115,7 +125,7 @@ struct SwiftcordApp: App {
 					? .dark
 					: (selectedTheme == "light" ? .light : .none)
 				)
-		}
+		}.contentSizedWindowResizability()
 	}
 }
 

--- a/Swiftcord/SwiftcordApp.swift
+++ b/Swiftcord/SwiftcordApp.swift
@@ -90,11 +90,14 @@ struct SwiftcordApp: App {
 			}
 		}
 		.commands {
-			#if !APP_STORE
 			CommandGroup(after: .appInfo) {
+				#if !APP_STORE
 				CheckForUpdatesView(updaterViewModel: updaterViewModel)
+				#endif
+				if #available(macOS 13, *) {
+					SettingsCommands()
+				}
 			}
-			#endif
 
 			SidebarCommands()
 			NavigationCommands(state: state, gateway: gateway)
@@ -102,7 +105,7 @@ struct SwiftcordApp: App {
 		.windowStyle(.hiddenTitleBar)
 		.windowToolbarStyle(.unified)
 
-		Settings {
+		WindowGroup(id: "settings") { // Identify the window group.
 			SettingsView()
 				.environmentObject(gateway)
 				.environmentObject(state)
@@ -112,7 +115,18 @@ struct SwiftcordApp: App {
 					? .dark
 					: (selectedTheme == "light" ? .light : .none)
 				)
-				// .environment(\.locale, .init(identifier: "zh-Hans"))
 		}
+	}
+}
+
+@available(macOS 13, *)
+struct SettingsCommands: View {
+	@Environment(\.openWindow) private var openWindow
+
+	var body: some View {
+		Divider()
+		Button("Settings") {
+			openWindow(id: "settings")
+		}.keyboardShortcut(",", modifiers: .command)
 	}
 }

--- a/Swiftcord/Views/Settings/App/AppSettingsAdvancedView.swift
+++ b/Swiftcord/Views/Settings/App/AppSettingsAdvancedView.swift
@@ -10,6 +10,7 @@ import AppCenterAnalytics
 
 struct AppSettingsAdvancedView: View {
 	@AppStorage("local.analytics") private var analyticsEnabled = true
+	@AppStorage("local.newSettingsUI") private var newSettingsUI = true
 	@State private var hasToggledAnalytics = false
 
     var body: some View {
@@ -37,6 +38,23 @@ struct AppSettingsAdvancedView: View {
 			Divider()
 
 			Text("settings.app.advanced.crashes")
+
+			Divider()
+
+			Text("Interface Trial")
+				.font(.headline)
+				.textCase(.uppercase)
+				.opacity(0.75)
+			VStack(alignment: .leading) {
+				Toggle(isOn: $newSettingsUI) {
+					Text("Try new Settings UI beta").frame(maxWidth: .infinity, alignment: .leading)
+				}
+				.toggleStyle(.switch)
+				.tint(.green)
+				if newSettingsUI {
+					Text("Keep in mind that this new UI is not yet fully functional").font(.caption)
+				}
+			}
 		}
     }
 }

--- a/Swiftcord/Views/Settings/SettingsView.swift
+++ b/Swiftcord/Views/Settings/SettingsView.swift
@@ -75,8 +75,13 @@ private extension SettingsView {
 			let icon: Icon?
 
 			struct Icon: Hashable {
+				enum IconResource: Equatable, Hashable {
+					case system(_ name: String)
+					case asset(_ name: String)
+				}
+
 				let baseColor: Color
-				let icon: String
+				let icon: IconResource
 			}
 
 			enum Name: String {
@@ -110,27 +115,27 @@ private extension SettingsView {
 		}
 		private static let pages: [Page] = [
 			.init(.userSection, children: [
-				.init(.account, icon: .init(baseColor: .blue, icon: "person.fill")),
-				.init(.profile, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.privacy, icon: .init(baseColor: .red, icon: "shield.lefthalf.filled"))
+				.init(.account, icon: .init(baseColor: .blue, icon: .system("person.fill"))),
+				.init(.profile, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.privacy, icon: .init(baseColor: .red, icon: .system("shield.lefthalf.filled")))
 			]),
 			.init(.paymentSection, children: [
-				.init(.nitro, icon: .init(baseColor: .accentColor, icon: "person.crop.circle")),
-				.init(.boost, icon: .init(baseColor: .green, icon: "person.crop.circle")),
-				.init(.subscriptions, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.gift, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.billing, icon: .init(baseColor: .blue, icon: "person.crop.circle"))
+				.init(.nitro, icon: .init(baseColor: .gray, icon: .asset("NitroSubscriber"))),
+				.init(.boost, icon: .init(baseColor: .green, icon: .system("person.crop.circle"))),
+				.init(.subscriptions, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.gift, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.billing, icon: .init(baseColor: .blue, icon: .system("person.crop.circle")))
 			]),
 			.init(.appSection, children: [
-				.init(.appearance, icon: .init(baseColor: .black, icon: "person.crop.circle")),
-				.init(.accessibility, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.voiceVideo, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.textImages, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.notifs, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.keybinds, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.lang, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.streamer, icon: .init(baseColor: .blue, icon: "person.crop.circle")),
-				.init(.advanced, icon: .init(baseColor: .blue, icon: "person.crop.circle"))
+				.init(.appearance, icon: .init(baseColor: .black, icon: .system("person.crop.circle"))),
+				.init(.accessibility, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.voiceVideo, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.textImages, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.notifs, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.keybinds, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.lang, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.streamer, icon: .init(baseColor: .blue, icon: .system("person.crop.circle"))),
+				.init(.advanced, icon: .init(baseColor: .blue, icon: .system("person.crop.circle")))
 			])
 		]
 
@@ -156,10 +161,17 @@ private extension SettingsView {
 							Text(item.nameString)
 						} icon: {
 							if let icon = item.icon {
-								Image(systemName: icon.icon)
-									.foregroundColor(.primary)
-									.frame(width: 20, height: 20)
-									.background(RoundedRectangle(cornerRadius: 5, style: .continuous).fill(icon.baseColor.gradient))
+								Group {
+									switch icon.icon {
+									case .system(let name):
+										Image(systemName: name)
+									case .asset(let name):
+										Image(name).resizable().padding(2)
+									}
+								}
+								.foregroundColor(.primary)
+								.frame(width: 20, height: 20)
+								.background(RoundedRectangle(cornerRadius: 5, style: .continuous).fill(icon.baseColor.gradient))
 							} else {
 								EmptyView()
 							}

--- a/Swiftcord/Views/Settings/SettingsView.swift
+++ b/Swiftcord/Views/Settings/SettingsView.swift
@@ -177,7 +177,7 @@ private extension SettingsView {
 							navigationItem(item: child)
 						}
 					}
-				}.frame(idealWidth: 215)
+				}.navigationSplitViewColumnWidth(215)
 			} detail: {
 				ScrollView {
 					Group {
@@ -194,10 +194,11 @@ private extension SettingsView {
 							Text("Unimplemented view: \(selectedPage.name.rawValue)")
 						}
 					}.padding(20)
-				}
+				}.navigationSplitViewColumnWidth(500)
 			}
 			.searchable(text: $filter, placement: .sidebar)
 			.navigationTitle(selectedPage.nameString)
+			.frame(minHeight: 470)
 		}
 	}
 

--- a/Swiftcord/Views/Settings/User/UserSettingsAccountView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsAccountView.swift
@@ -51,7 +51,6 @@ struct UserSettingsAccountView: View {
 
             GroupBox {
                 VStack(alignment: .leading, spacing: 4) {
-
                     Text("settings.user.phoneNum").textCase(.uppercase).font(.headline).opacity(0.75)
                     Text(user.phone ?? "You haven't added a phone number yet.")
                         .font(.system(size: 16))

--- a/Swiftcord/Views/Settings/User/UserSettingsAccountView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsAccountView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import DiscordKitCore
+import CachedAsyncImage
 
 struct UserSettingsAccountView: View {
 	let user: CurrentUser
@@ -37,74 +38,67 @@ struct UserSettingsAccountView: View {
 	}
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 16) {
-			Text("My Account").font(.title)
-			LargeUserProfile(user: user) {
-				GroupBox {
-					VStack(alignment: .leading, spacing: 4) {
-						Text("Username").textCase(.uppercase).font(.headline).opacity(0.75)
-						Group {
-							Text(user.username) + Text("#" + user.discriminator).foregroundColor(Color(NSColor.textColor).opacity(0.75))
-						}
-						.font(.system(size: 16))
-						.textSelection(.enabled)
+		VStack {
+            CachedAsyncImage(url: user.avatarURL(size: 240)) { image in
+                image.resizable().scaledToFill()
+            } placeholder: {
+                ProgressView().progressViewStyle(.circular)
+            }
+            .clipShape(Circle())
+            .frame(width: 100, height: 100)
+            Text(user.username).font(.title2)
+            Text(user.email)
 
-						Divider().padding(.vertical, 10)
+            GroupBox {
+                VStack(alignment: .leading, spacing: 4) {
 
-						Text("settings.user.email").textCase(.uppercase).font(.headline).opacity(0.75)
-						Text(user.email)
-							.font(.system(size: 16))
-							.textSelection(.enabled)
-
-						Divider().padding(.vertical, 10)
-
-						Text("settings.user.phoneNum").textCase(.uppercase).font(.headline).opacity(0.75)
-						Text(user.phone ?? "You haven't added a phone number yet.")
-							.font(.system(size: 16))
-							.textSelection(.enabled)
-					}.padding(10).frame(maxWidth: .infinity)
-				}
+                    Text("settings.user.phoneNum").textCase(.uppercase).font(.headline).opacity(0.75)
+                    Text(user.phone ?? "You haven't added a phone number yet.")
+                        .font(.system(size: 16))
+                        .textSelection(.enabled)
+                }.padding(10).frame(maxWidth: .infinity)
 			}
 
+            GroupBox {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Password and Authenthication").font(.title2)
+                    Divider()
+                    Button(action: { changePwSheetShown = true }) {
+                        Text("Change Password")
+                    }
+                    .buttonStyle(FlatButtonStyle())
+                    .controlSize(.small)
+                    .sheet(isPresented: $changePwSheetShown, onDismiss: {
+                        oldPw = ""
+                        newPw = ""
+                    }) { changePwDialog }
+
+                    Text("TWO-FACTOR AUTHENTHICATION" + (user.mfa_enabled ? " ENABLED" : ""))
+                        .font(.headline)
+                        .foregroundColor(user.mfa_enabled ? .green : nil)
+                        .padding(.top, 12)
+                    Text("Two-Factor authentication (2FA for short) is a good way to add an extra layer of security to your Discord account to make sure that only you have the ability to log in.")
+                        .opacity(0.75)
+                        .padding(.top, -8)
+
+                    HStack(spacing: 16) {
+                        Button("View Backup Codes") {
+
+                        }
+                        .buttonStyle(FlatButtonStyle())
+                        .controlSize(.small)
+                        Button("Remove 2FA", role: .destructive) {
+
+                        }
+                        .buttonStyle(FlatButtonStyle(outlined: true))
+                        .controlSize(.small)
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
 			Group {
-				Divider().padding(.vertical, 16)
-
-				Text("Password and Authenthication").font(.title)
-				Button(action: { changePwSheetShown = true }) {
-					Text("Change Password")
-				}
-				.buttonStyle(FlatButtonStyle())
-				.controlSize(.small)
-				.sheet(isPresented: $changePwSheetShown, onDismiss: {
-					oldPw = ""
-					newPw = ""
-				}) { changePwDialog }
-
-				Text("TWO-FACTOR AUTHENTHICATION" + (user.mfa_enabled ? " ENABLED" : ""))
-					.font(.headline)
-					.foregroundColor(user.mfa_enabled ? .green : nil)
-					.padding(.top, 12)
-				Text("Two-Factor authentication (2FA for short) is a good way to add an extra layer of security to your Discord account to make sure that only you have the ability to log in.")
-					.opacity(0.75)
-					.padding(.top, -8)
-
-				HStack(spacing: 16) {
-					Button("View Backup Codes") {
-
-					}
-					.buttonStyle(FlatButtonStyle())
-					.controlSize(.small)
-					Button("Remove 2FA", role: .destructive) {
-
-					}
-					.buttonStyle(FlatButtonStyle(outlined: true))
-					.controlSize(.small)
-				}
-			}
-
-			Group {
-				Divider().padding(.vertical, 16)
-
 				Text("ACCOUNT REMOVAL")
 					.font(.headline)
 				Text("Disabling your account means you can recover it at any time after taking this action.")
@@ -123,8 +117,6 @@ struct UserSettingsAccountView: View {
 					.controlSize(.small)
 				}
 			}
-
-			Spacer()
 		}
 	}
 }

--- a/Swiftcord/Views/Settings/User/UserSettingsProfileView.swift
+++ b/Swiftcord/Views/Settings/User/UserSettingsProfileView.swift
@@ -16,8 +16,6 @@ struct UserSettingsProfileView: View {
 
     var body: some View {
 		VStack(alignment: .leading, spacing: 16) {
-			Text("User Profile").font(.title)
-
 			HStack(alignment: .top) {
 				VStack(alignment: .leading) {
 					Text("About Me").textCase(.uppercase).font(.headline)

--- a/Swiftcord/Views/User/Avatar/UserAvatarView.swift
+++ b/Swiftcord/Views/User/Avatar/UserAvatarView.swift
@@ -99,6 +99,7 @@ struct UserAvatarView: View, Equatable {
 						)
 						.font(.headline)
 						.textCase(.uppercase)
+						.padding(.top, 6)
 						if !roles.isEmpty {
 							TagCloudView(
 								content: roles.map { role in
@@ -124,7 +125,10 @@ struct UserAvatarView: View, Equatable {
 							.tint(.blue)
 					}
 				}
-				Text("user.note").font(.headline).textCase(.uppercase)
+				Text("user.note")
+					.font(.headline)
+					.textCase(.uppercase)
+					.padding(.top, 6)
 				// Notes are stored locally for now, but eventually will be synced with the Discord API
 				TextField("Add a note to this user (only visible to you)", text: $note)
 					.textFieldStyle(.roundedBorder)

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -125,7 +125,7 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 							.fixedSize(horizontal: false, vertical: true)
 					}
 
-					contentSlot.padding(.top, 6)
+					contentSlot
 				}
 			}
 			.padding(12)


### PR DESCRIPTION
Overhauls Swiftcord's settings to closely match macOS Ventura's new settings style. Adopting 

This is where we're at currently:
<img width="824" alt="Screenshot 2023-04-23 at 12 30 20 AM" src="https://user-images.githubusercontent.com/64193267/233795982-550c1796-4f64-4006-b474-4fd6b047ca20.png">

The behaviour of the Settings window and navigation has been complete, however the detail views themselves still need some work. 