### PR TITLE
Added a Username Copy Button

### DIFF
--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -12,6 +12,9 @@ import CachedAsyncImage
 
 struct MiniUserProfileView<RichContentSlot: View>: View {
 	let user: User
+	
+	let pasteboard = NSPasteboard.general
+	
 	@Binding var profile: UserProfile?
 	var guildRoles: [Role]?
 	var isWebhook: Bool = false
@@ -90,6 +93,15 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 						NonUserBadge(flags: user.public_flags, isWebhook: isWebhook)
 					}
 					Spacer()
+					Button(action: {
+						pasteboard.declareTypes([.string], owner: nil)
+						pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
+					}, label: {
+						Image(systemName: "square.on.square")
+					})
+					.buttonStyle(.plain)
+					.padding()
+					.frame(width: 20, height: 20)
 				}
 
 				// Custom status

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -12,9 +12,7 @@ import CachedAsyncImage
 
 struct MiniUserProfileView<RichContentSlot: View>: View {
 	let user: User
-	
 	let pasteboard = NSPasteboard.general
-	
 	@Binding var profile: UserProfile?
 	var guildRoles: [Role]?
 	var isWebhook: Bool = false


### PR DESCRIPTION
### **Summery**
A Button to directly copy user and discrim from the mini profile page.
### **How it works**
Uses pasteboard to copy to clipboard, grabs the "user.username" and "user.discriminator" and interpolates it with a "#" to form a string "Username#1234" that gets copied to the clipboard.
### **Code that was added**
`let pasteboard = NSPasteboard.general`

`		Button(action: {
						pasteboard.declareTypes([.string], owner: nil)
						pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
					}, label: {
						Image(systemName: "square.on.square")
					})
					.buttonStyle(.plain)
					.padding()
					.frame(width: 20, height: 20)
`

All in all, a very simple ease of life change.

### **Examples**
<img width="341" alt="image" src="https://github.com/SwiftcordApp/Swiftcord/assets/78669085/e686b2e3-d8d2-404d-9ca9-5f479905c380">
