### PR TITLE
Redid Account Overview Page

### DIFF
--- a/Swiftcord/Views/Settings/User/AccountOverview.swift
+++ b/Swiftcord/Views/Settings/User/AccountOverview.swift
@@ -25,27 +25,108 @@ struct AccountOverview: View {
 				UserInfo()
 			}
 		} header: {
-			VStack(spacing: 0) {
-				CachedAsyncImage(url: user.avatarURL(size: 240)) { image in
-					image.resizable().scaledToFill()
-				} placeholder: {
-					ProgressView().progressViewStyle(.circular)
+			VStack {
+				HStack(spacing: 0) {
+					CachedAsyncImage(url: user.avatarURL(size: 240)) { image in
+						image.resizable().scaledToFill()
+					} placeholder: {
+						ProgressView().progressViewStyle(.circular)
+					}
+					.clipShape(Circle())
+					.frame(width: 70, height: 70)
+					.padding(5)
+					.overlay {
+						Circle()
+							.strokeBorder(.white.opacity(0.5), lineWidth: 2)
+					}
+					.padding()
+					VStack(alignment: .leading) {
+						Text(user.username).font(.title)/*.padding(.top, 6)*/
+						Text("#" + user.discriminator)
+							.font(.system(.title3, weight: .bold))
+					}
+					Spacer()
+					Button(action: {
+						if let url = URL(string: "https://discord.com/channels/@me") {
+								NSWorkspace.shared.open(url)
+							}
+					}, label: {
+						HStack {
+							Text("Edit Profile")
+							Image(systemName: "link")
+						}
+						.frame(width: 131, height: 32)
+						.background(Color.accentColor)
+						.cornerRadius(5)
+					})
+					.buttonStyle(.plain)
 				}
-				.clipShape(Circle())
-				.frame(width: 100, height: 100)
-				Text(user.username).font(.title2).padding(.top, 6)
-				Text(user.email).font(.system(.title3, weight: .regular))
-				if let phone = user.phone {
-					Text(phone)
-						.textSelection(.enabled)
+				.padding()
+				//.background(Color.green.opacity(0.5))
+				VStack {
+					List {
+						HStack {
+							VStack(alignment: .leading) {
+								Text("Display Name")
+									.font(.system(.title3, weight: .bold))
+								Text(user.username)
+									.font(.system(.title3, weight: .regular))
+							}
+							Spacer()
+//							Button(action: {}, label: {
+//								HStack {
+//									Text("Learn More")
+//									Image(systemName: "link")
+//								}
+//								.frame(height: 32)
+//								.padding(.leading, 20)
+//								.padding(.trailing, 20)
+//								.background(Color.accentColor)
+//								.cornerRadius(5)
+//							})
+//							.buttonStyle(.plain)
+						}
+						HStack {
+							VStack(alignment: .leading) {
+								Text("Username")
+									.font(.system(.title3, weight: .bold))
+								Text(user.username + "#" + user.discriminator)
+									.font(.system(.title3, weight: .regular))
+							}
+							Spacer()
+						}
+						HStack {
+							VStack(alignment: .leading) {
+								Text("Email")
+									.font(.system(.title3, weight: .bold))
+								Text(user.email)
+									.font(.system(.title3, weight: .regular))
+							}
+							Spacer()
+						}
+						if let phone = user.phone {
+							HStack {
+								VStack(alignment: .leading) {
+									Text("Phone")
+										.font(.system(.title3, weight: .bold))
+									Text(phone)
+										.font(.system(.title3, weight: .regular))
+								}
+								Spacer()
+							}
+						}
+					}
+					.cornerRadius(15)
+					.padding()
 				}
 			}
 			.foregroundColor(.primary)
 			.frame(maxWidth: .infinity)
 			.padding(.top, -10)
 			.padding(.bottom, 10)
+			.background(Color.black.opacity(0.4))
+			.cornerRadius(15)
 		}
-
 		Section {
 			HStack {
 				Button("Disable Account", role: .destructive) {

--- a/Swiftcord/Views/Settings/User/AccountOverview.swift
+++ b/Swiftcord/Views/Settings/User/AccountOverview.swift
@@ -67,39 +67,9 @@ struct AccountOverview: View {
 					List {
 						HStack {
 							VStack(alignment: .leading) {
-								Text("Display Name")
-									.font(.system(.title3, weight: .bold))
-								Text(user.username)
-									.font(.system(.title3, weight: .regular))
-							}
-							Spacer()
-//							Button(action: {}, label: {
-//								HStack {
-//									Text("Learn More")
-//									Image(systemName: "link")
-//								}
-//								.frame(height: 32)
-//								.padding(.leading, 20)
-//								.padding(.trailing, 20)
-//								.background(Color.accentColor)
-//								.cornerRadius(5)
-//							})
-//							.buttonStyle(.plain)
-						}
-						HStack {
-							VStack(alignment: .leading) {
-								Text("Username")
+								Text("Name")
 									.font(.system(.title3, weight: .bold))
 								Text(user.username + "#" + user.discriminator)
-									.font(.system(.title3, weight: .regular))
-							}
-							Spacer()
-						}
-						HStack {
-							VStack(alignment: .leading) {
-								Text("Email")
-									.font(.system(.title3, weight: .bold))
-								Text(user.email)
 									.font(.system(.title3, weight: .regular))
 							}
 							Spacer()
@@ -114,6 +84,25 @@ struct AccountOverview: View {
 								}
 								Spacer()
 							}
+						} else {
+							HStack {
+								VStack(alignment: .leading) {
+									Text("Phone")
+										.font(.system(.title3, weight: .bold))
+									Text("No Phone Number Added")
+										.font(.system(.title3, weight: .regular))
+								}
+								Spacer()
+							}
+						}
+						HStack {
+							VStack(alignment: .leading) {
+								Text("Email")
+									.font(.system(.title3, weight: .bold))
+								Text(user.email)
+									.font(.system(.title3, weight: .regular))
+							}
+							Spacer()
 						}
 					}
 					.cornerRadius(15)

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -12,6 +12,9 @@ import CachedAsyncImage
 
 struct MiniUserProfileView<RichContentSlot: View>: View {
 	let user: User
+	
+	let pasteboard = NSPasteboard.general
+	
 	@Binding var profile: UserProfile?
 	var guildRoles: [Role]?
 	var isWebhook: Bool = false
@@ -90,6 +93,15 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 						NonUserBadge(flags: user.public_flags, isWebhook: isWebhook)
 					}
 					Spacer()
+					Button(action: {
+						pasteboard.declareTypes([.string], owner: nil)
+						pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
+					}, label: {
+						Image(systemName: "square.on.square")
+					})
+					.buttonStyle(.plain)
+					.padding()
+					.frame(width: 20, height: 20)
 				}
 
 				// Custom status

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -12,9 +12,7 @@ import CachedAsyncImage
 
 struct MiniUserProfileView<RichContentSlot: View>: View {
 	let user: User
-	
 	let pasteboard = NSPasteboard.general
-	
 	@Binding var profile: UserProfile?
 	var guildRoles: [Role]?
 	var isWebhook: Bool = false


### PR DESCRIPTION
### What does this do?
This gives a more "Discord Like" Look to the account overview page, more of a preview style.
### Why do I think this is the right solution?
This mixes elements of both discord and Icloud together, still gives off a apple vibe, but fits more with the discord style.
### Screenshots (Before and After)
Before
![CleanShot 2023-05-18 at 09 57 41@2x](https://github.com/SwiftcordApp/Swiftcord/assets/78669085/9024d106-23c6-4f47-86ea-15fe0708ce84)
After
![CleanShot 2023-05-18 at 11 50 28@2x](https://github.com/SwiftcordApp/Swiftcord/assets/78669085/ff8ada39-30ad-4a25-9a0e-0b1dd9ca9a21)

