### PR TITLE
Fix: Weird localization words order in onboarding title screen.

### DIFF
--- a/Swiftcord/Views/OnboardingView.swift
+++ b/Swiftcord/Views/OnboardingView.swift
@@ -16,11 +16,24 @@ struct OnboardingWelcomeView: View {
 	var body: some View {
 		VStack(alignment: .leading, spacing: 16) {
 			Group {
-				Text("onboarding.title").font(.largeTitle)
-				+ Text(appName ?? "")
+				let highlightStyle = AttributeContainer
 					.foregroundColor(.accentColor)
-					.font(.system(size: 72))
-					.fontWeight(.heavy)
+					.font(.system(size: 72).weight(.heavy))
+
+				var attributedTitle: AttributedString {
+					var attributedString: AttributedString = .init(localized: "onboarding.title \(appName ?? "")")
+
+					attributedString.replaceAttributes(
+						AttributeContainer.inlinePresentationIntent(.stronglyEmphasized),
+						with: highlightStyle
+					)
+
+					return attributedString
+				}
+
+				Text(attributedTitle)
+					.font(.largeTitle)
+
 				Text("onboarding.subtitle").padding(.top, -20)
 			}
 			.padding(.top, 6)

--- a/Swiftcord/Views/OnboardingView.swift
+++ b/Swiftcord/Views/OnboardingView.swift
@@ -16,17 +16,15 @@ struct OnboardingWelcomeView: View {
 	var body: some View {
 		VStack(alignment: .leading, spacing: 16) {
 			Group {
-				let highlightStyle = AttributeContainer
-					.foregroundColor(.accentColor)
-					.font(.system(size: 72).weight(.heavy))
-
 				var attributedTitle: AttributedString {
 					var attributedString: AttributedString = .init(localized: "onboarding.title \(appName ?? "")")
 
-					attributedString.replaceAttributes(
-						AttributeContainer.inlinePresentationIntent(.stronglyEmphasized),
-						with: highlightStyle
-					)
+					let appNameRange = attributedString.range(of: appName ?? "")
+
+					if let appNameRange = appNameRange {
+						attributedString[appNameRange].foregroundColor = .accentColor
+						attributedString[appNameRange].font = .system(size: 72).weight(.heavy)
+					}
 
 					return attributedString
 				}

--- a/Swiftcord/de.lproj/Localizable.strings
+++ b/Swiftcord/de.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "action.continue" = "Fortfahren";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Willkommen zu\n";
+"onboarding.title %@" = "Willkommen zu\n**%@**";
 "onboarding.subtitle" = "Ein Discord-Client konzipiert für macOS";
 "onboarding.lightweight.header" = "Effizient — Ressourcen schonend";
 "onboarding.lightweight.body" = "Verbraucht bis zu 7x weniger RAM als Discord bei wenig CPU-Last.";

--- a/Swiftcord/de.lproj/Localizable.strings
+++ b/Swiftcord/de.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "action.continue" = "Fortfahren";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Willkommen zu\n**%@**";
+"onboarding.title %@" = "Willkommen zu\n%@";
 "onboarding.subtitle" = "Ein Discord-Client konzipiert für macOS";
 "onboarding.lightweight.header" = "Effizient — Ressourcen schonend";
 "onboarding.lightweight.body" = "Verbraucht bis zu 7x weniger RAM als Discord bei wenig CPU-Last.";

--- a/Swiftcord/en.lproj/Localizable.strings
+++ b/Swiftcord/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.close" = "Close";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Welcome to\n**%@**";
+"onboarding.title %@" = "Welcome to\n%@";
 "onboarding.subtitle" = "A Discord client built and designed for macOS";
 "onboarding.lightweight.header" = "Efficient — Light on Resources";
 "onboarding.lightweight.body" = "Up to 7x less RAM than Discord, with low CPU usage.";

--- a/Swiftcord/en.lproj/Localizable.strings
+++ b/Swiftcord/en.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.close" = "Close";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Welcome to\n";
+"onboarding.title %@" = "Welcome to\n**%@**";
 "onboarding.subtitle" = "A Discord client built and designed for macOS";
 "onboarding.lightweight.header" = "Efficient — Light on Resources";
 "onboarding.lightweight.body" = "Up to 7x less RAM than Discord, with low CPU usage.";

--- a/Swiftcord/fr.lproj/Localizable.strings
+++ b/Swiftcord/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.continue" = "Continuer";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Bienvenue sur\n**%@**";
+"onboarding.title %@" = "Bienvenue sur\n%@";
 "onboarding.subtitle" = "Un client Discord construit et conçu pour macOS";
 "onboarding.lightweight.body" = "Utilise jusqu'à 7 fois moins de mémoire vive que Discord, avec très peu d'utilisation du processeur.";
 "onboarding.features.header" = "Riche en fonctionnalités";

--- a/Swiftcord/fr.lproj/Localizable.strings
+++ b/Swiftcord/fr.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.continue" = "Continuer";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Bienvenue sur\n";
+"onboarding.title %@" = "Bienvenue sur\n**%@**";
 "onboarding.subtitle" = "Un client Discord construit et conçu pour macOS";
 "onboarding.lightweight.body" = "Utilise jusqu'à 7 fois moins de mémoire vive que Discord, avec très peu d'utilisation du processeur.";
 "onboarding.features.header" = "Riche en fonctionnalités";

--- a/Swiftcord/he.lproj/Localizable.strings
+++ b/Swiftcord/he.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "action.continue" = "המשך";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "ברוכים הביים ל\n";
+"onboarding.title %@" = "ברוכים הביים ל\n**%@**";
 "action.done" = "בוצע";
 "action.close" = "סגור";
 "onboarding.lightweight.header" = "יעיל - פחות מעמיס על המחשב.";

--- a/Swiftcord/he.lproj/Localizable.strings
+++ b/Swiftcord/he.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "action.continue" = "המשך";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "ברוכים הביים ל\n**%@**";
+"onboarding.title %@" = "ברוכים הביים ל\n%@";
 "action.done" = "בוצע";
 "action.close" = "סגור";
 "onboarding.lightweight.header" = "יעיל - פחות מעמיס על המחשב.";

--- a/Swiftcord/it.lproj/Localizable.strings
+++ b/Swiftcord/it.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "action.continue" = "Prosegui";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Benvenuto su\n**%@**";
+"onboarding.title %@" = "Benvenuto su\n%@";
 "onboarding.subtitle" = "Un client Discord costruito e disegnato per macOS";
 "user.roles.one" = "Ruolo";
 "user.roles.many" = "Ruoli";

--- a/Swiftcord/it.lproj/Localizable.strings
+++ b/Swiftcord/it.lproj/Localizable.strings
@@ -6,7 +6,7 @@
 "action.continue" = "Prosegui";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Benvenuto su\n";
+"onboarding.title %@" = "Benvenuto su\n**%@**";
 "onboarding.subtitle" = "Un client Discord costruito e disegnato per macOS";
 "user.roles.one" = "Ruolo";
 "user.roles.many" = "Ruoli";

--- a/Swiftcord/ja.lproj/Localizable.strings
+++ b/Swiftcord/ja.lproj/Localizable.strings
@@ -111,7 +111,7 @@
 "action.continue" = "続ける";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "**%@**\nへようこそ！";
+"onboarding.title %@" = "%@\nへようこそ！";
 "onboarding.lightweight.body" = "CPU 使用率が低く、RAM が Discord の最大 7 分の 1 です。";
 "onboarding.wip.body" = "何か問題がありますか？ GitHub の問題を作成するか、Discord サーバーで問題を報告してください";
 "onboarding.footer" = "Swiftcord はアルファ版ソフトウェアであり、制限やバグがあります。 現時点では、公式クライアントを置き換える予定はありませんが、いつかは置き換えられることを望んでいます。";

--- a/Swiftcord/ja.lproj/Localizable.strings
+++ b/Swiftcord/ja.lproj/Localizable.strings
@@ -111,7 +111,7 @@
 "action.continue" = "続ける";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "へようこそ！\n";
+"onboarding.title %@" = "**%@**\nへようこそ！";
 "onboarding.lightweight.body" = "CPU 使用率が低く、RAM が Discord の最大 7 分の 1 です。";
 "onboarding.wip.body" = "何か問題がありますか？ GitHub の問題を作成するか、Discord サーバーで問題を報告してください";
 "onboarding.footer" = "Swiftcord はアルファ版ソフトウェアであり、制限やバグがあります。 現時点では、公式クライアントを置き換える予定はありませんが、いつかは置き換えられることを望んでいます。";

--- a/Swiftcord/ko.lproj/Localizable.strings
+++ b/Swiftcord/ko.lproj/Localizable.strings
@@ -70,7 +70,7 @@
 "server.noChannels.header" = "채팅 채널 없음";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "환영합니다\n**%@**";
+"onboarding.title %@" = "환영합니다\n%@";
 "server.channel.title %@" = "#%@에 오신 걸 환영합니다!";
 "server.channel.header %@ %@" = "#%@ 채널의 시작이에요. %@";
 "loader.panic.logout" = "시간이 좀 걸리네요, 로그아웃하시겠어요?";

--- a/Swiftcord/ko.lproj/Localizable.strings
+++ b/Swiftcord/ko.lproj/Localizable.strings
@@ -70,7 +70,7 @@
 "server.noChannels.header" = "채팅 채널 없음";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "환영합니다\n";
+"onboarding.title %@" = "환영합니다\n**%@**";
 "server.channel.title %@" = "#%@에 오신 걸 환영합니다!";
 "server.channel.header %@ %@" = "#%@ 채널의 시작이에요. %@";
 "loader.panic.logout" = "시간이 좀 걸리네요, 로그아웃하시겠어요?";

--- a/Swiftcord/nb-NO.lproj/Localizable.strings
+++ b/Swiftcord/nb-NO.lproj/Localizable.strings
@@ -65,7 +65,7 @@
 "action.continue" = "Fortsett";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Velkommen til\n";
+"onboarding.title %@" = "Velkommen til\n**%@**";
 "onboarding.wip.body" = "Er noe galt? Opprett en feilrapport på GitHub, eller levn en melding i vår Discord-tjener";
 "onboarding.footer" = "Alfa-programvare, med begrensninger og feil. Tar foreløpig kun sikte å erstatte den offisielle klienten.";
 "dm.group.composeMsg.hint %@" = "Melding %@";

--- a/Swiftcord/nb-NO.lproj/Localizable.strings
+++ b/Swiftcord/nb-NO.lproj/Localizable.strings
@@ -65,7 +65,7 @@
 "action.continue" = "Fortsett";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Velkommen til\n**%@**";
+"onboarding.title %@" = "Velkommen til\n%@";
 "onboarding.wip.body" = "Er noe galt? Opprett en feilrapport på GitHub, eller levn en melding i vår Discord-tjener";
 "onboarding.footer" = "Alfa-programvare, med begrensninger og feil. Tar foreløpig kun sikte å erstatte den offisielle klienten.";
 "dm.group.composeMsg.hint %@" = "Melding %@";

--- a/Swiftcord/nl.lproj/Localizable.strings
+++ b/Swiftcord/nl.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.close" = "Dicht";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Welkom bij\n";
+"onboarding.title %@" = "Welkom bij\n**%@**";
 "onboarding.subtitle" = "Een Discord client gemaakt en ontworpen voor macOS";
 "onboarding.lightweight.header" = "Efficiënt - Gebruikt niet veel Bronnen";
 "onboarding.features.header" = "Goed Aanbevolen";

--- a/Swiftcord/nl.lproj/Localizable.strings
+++ b/Swiftcord/nl.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 "action.close" = "Dicht";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Welkom bij\n**%@**";
+"onboarding.title %@" = "Welkom bij\n%@";
 "onboarding.subtitle" = "Een Discord client gemaakt en ontworpen voor macOS";
 "onboarding.lightweight.header" = "Efficiënt - Gebruikt niet veel Bronnen";
 "onboarding.features.header" = "Goed Aanbevolen";

--- a/Swiftcord/pl.lproj/Localizable.strings
+++ b/Swiftcord/pl.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "action.close" = "Zamknij";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Witaj w aplikacji\n**%@**";
+"onboarding.title %@" = "Witaj w aplikacji\n%@";
 "onboarding.subtitle" = "Będącej klientem Discorda zbudowanym specjalnie dla systemu MacOS";
 "onboarding.lightweight.header" = "Wygodnym i lekkim";
 "onboarding.lightweight.body" = "Zużywającym nawet 7 razy mniej pamięci RAM.";

--- a/Swiftcord/pl.lproj/Localizable.strings
+++ b/Swiftcord/pl.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 "action.close" = "Zamknij";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Witaj w aplikacji\n";
+"onboarding.title %@" = "Witaj w aplikacji\n**%@**";
 "onboarding.subtitle" = "Będącej klientem Discorda zbudowanym specjalnie dla systemu MacOS";
 "onboarding.lightweight.header" = "Wygodnym i lekkim";
 "onboarding.lightweight.body" = "Zużywającym nawet 7 razy mniej pamięci RAM.";

--- a/Swiftcord/ru.lproj/Localizable.strings
+++ b/Swiftcord/ru.lproj/Localizable.strings
@@ -9,7 +9,7 @@
 "action.continue" = "Продолжить";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Добро пожаловать в\n";
+"onboarding.title %@" = "Добро пожаловать в\n**%@**";
 "onboarding.features.body" = "Основные функции присутствуют, и ведется работа над добавлением новых";
 "onboarding.lightweight.header" = "Эффективный - Легкая системная нагрузка";
 "onboarding.lightweight.body" = "Использование оперативной памияти до 7 раз меньше, чем в Discord, при низкой загрузке процессора.";

--- a/Swiftcord/ru.lproj/Localizable.strings
+++ b/Swiftcord/ru.lproj/Localizable.strings
@@ -9,7 +9,7 @@
 "action.continue" = "Продолжить";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Добро пожаловать в\n**%@**";
+"onboarding.title %@" = "Добро пожаловать в\n%@";
 "onboarding.features.body" = "Основные функции присутствуют, и ведется работа над добавлением новых";
 "onboarding.lightweight.header" = "Эффективный - Легкая системная нагрузка";
 "onboarding.lightweight.body" = "Использование оперативной памияти до 7 раз меньше, чем в Discord, при низкой загрузке процессора.";

--- a/Swiftcord/tr.lproj/Localizable.strings
+++ b/Swiftcord/tr.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 "action.close" = "Kapat";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "Hoş geldiniz\n**%@**";
+"onboarding.title %@" = "Hoş geldiniz\n%@";
 "onboarding.subtitle" = "macOS için tasarlanmış bir Discord istemcisi";
 "onboarding.lightweight.header" = "Verimli - Kaynak Kullanımı Hafif";
 "onboarding.lightweight.body" = "Düşük işlemci kullanımı ile Discord'a göre 7 kat daha az RAM kullanır.";

--- a/Swiftcord/tr.lproj/Localizable.strings
+++ b/Swiftcord/tr.lproj/Localizable.strings
@@ -7,7 +7,7 @@
 "action.close" = "Kapat";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "Hoş geldiniz\n";
+"onboarding.title %@" = "Hoş geldiniz\n**%@**";
 "onboarding.subtitle" = "macOS için tasarlanmış bir Discord istemcisi";
 "onboarding.lightweight.header" = "Verimli - Kaynak Kullanımı Hafif";
 "onboarding.lightweight.body" = "Düşük işlemci kullanımı ile Discord'a göre 7 kat daha az RAM kullanır.";

--- a/Swiftcord/zh-Hans.lproj/Localizable.strings
+++ b/Swiftcord/zh-Hans.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "action.continue" = "继续";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "欢迎使用\n**%@**";
+"onboarding.title %@" = "欢迎使用\n%@";
 "onboarding.subtitle" = "专为macOS打造和设计的Discord客户端";
 "onboarding.lightweight.header" = "高效—轻量级的资源";
 "onboarding.lightweight.body" = "使用的内存比Discord少7倍，CPU使用率低。";

--- a/Swiftcord/zh-Hans.lproj/Localizable.strings
+++ b/Swiftcord/zh-Hans.lproj/Localizable.strings
@@ -2,7 +2,7 @@
 "action.continue" = "继续";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "欢迎使用\n";
+"onboarding.title %@" = "欢迎使用\n**%@**";
 "onboarding.subtitle" = "专为macOS打造和设计的Discord客户端";
 "onboarding.lightweight.header" = "高效—轻量级的资源";
 "onboarding.lightweight.body" = "使用的内存比Discord少7倍，CPU使用率低。";

--- a/Swiftcord/zh-Hant.lproj/Localizable.strings
+++ b/Swiftcord/zh-Hant.lproj/Localizable.strings
@@ -24,7 +24,7 @@
 "settings.app.advanced.analytics.caption" = "我們將通過Appcenter收集匯總（匿名）的使用統計資料（如渲染語言，應用程式版本和功能的使用狀態）。所獲取的資料將用於提升Swiftcord的功能體驗；我們無法以此資料追蹤到你身上。";
 
 /* ====== Onboarding ====== */
-"onboarding.title %@" = "歡迎使用\n**%@**";
+"onboarding.title %@" = "歡迎使用\n%@";
 "onboarding.subtitle" = "一個專門為macOS打造和設計的Discord用戶端";
 "onboarding.lightweight.body" = "記憶體使用率較Discord少高達7倍，且CPU使用率亦較低。";
 "onboarding.features.header" = "功能完善";

--- a/Swiftcord/zh-Hant.lproj/Localizable.strings
+++ b/Swiftcord/zh-Hant.lproj/Localizable.strings
@@ -24,7 +24,7 @@
 "settings.app.advanced.analytics.caption" = "我們將通過Appcenter收集匯總（匿名）的使用統計資料（如渲染語言，應用程式版本和功能的使用狀態）。所獲取的資料將用於提升Swiftcord的功能體驗；我們無法以此資料追蹤到你身上。";
 
 /* ====== Onboarding ====== */
-"onboarding.title" = "歡迎使用\n";
+"onboarding.title %@" = "歡迎使用\n**%@**";
 "onboarding.subtitle" = "一個專門為macOS打造和設計的Discord用戶端";
 "onboarding.lightweight.body" = "記憶體使用率較Discord少高達7倍，且CPU使用率亦較低。";
 "onboarding.features.header" = "功能完善";


### PR DESCRIPTION
# About this Pull Request

This pull request fixed a problem that onboarding title words order was wrong on Japanese.

## What was the problem?

The Japanese localization of "onboarding.title" should be "Swiftcord へようこそ" but because of a localization interpolation code was wrong, so it had been shown "へようこそ Swiftcord".


<img width="280" alt="スクリーンショット 2023-05-26 午後6 05 50_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/bce9c31a-6b14-470e-8630-06c23a81e3a6">

<br><br>

To convey that the word order in "へようこそ Swiftcord" is grammatically incorrect in Japanese, you can use the following translation in English like this:

Translation: Swiftcord to welcome .

I hope you realize such weird words order.

## Screenshots (Before and After)

This section also stands for proving there are no regressions.

|    |Before|After|
|---|---|---|
| Chinese, Simplified | <img width="451" alt="スクリーンショット 2023-05-26 午後6 07 19_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/a0f300a6-3a13-4b20-8a66-ec7c8458c85c"> | <img width="450" alt="スクリーンショット 2023-05-26 午後6 19 09" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/31bf5c20-f215-424c-9764-9d5b669e256a"> |
| Chinese, Traditional | <img width="450" alt="スクリーンショット 2023-05-26 午後6 07 54_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/05fa3344-84ed-4fba-a43c-34349f31546b"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 19 47" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/19b48cbf-3d22-469c-94bd-39ac4beba680"> |
| Dutch | <img width="451" alt="スクリーンショット 2023-05-26 午後6 08 27_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/bd05d0c4-2420-4d8e-b75f-11336e45636a"> | <img width="450" alt="スクリーンショット 2023-05-26 午後6 20 29" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/2748260f-af76-4bdc-b228-1841436576a0"> |
| English | <img width="450" alt="スクリーンショット 2023-05-26 午後6 06 50_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/1d6ed1fa-e075-4c2c-bc9f-0329d99208cb"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 21 08" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/1a6e0554-b25a-469a-8345-41d5148ebd0d"> |
| French | <img width="450" alt="スクリーンショット 2023-05-26 午後6 09 47_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/454b9de3-0b6e-4e68-87cf-5c502653d99a"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 21 34" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/60ca67de-b135-4134-b2a3-e8d8d8c2e791"> |
| German | <img width="452" alt="スクリーンショット 2023-05-26 午後6 10 11_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/a11de5c4-6764-44c6-9e1a-c434ca1550b4"> | <img width="450" alt="スクリーンショット 2023-05-26 午後6 21 59" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/e7361e4c-758e-4d20-93fd-8a491eca0714"> |
| Hebrew | <img width="452" alt="スクリーンショット 2023-05-26 午後6 10 36_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/3d53c3eb-dc7d-4876-9d1a-897d237c7cda"> | <img width="449" alt="スクリーンショット 2023-05-26 午後6 22 37" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/e2d8932c-9e7b-4ad3-aae5-c16bf6aa4bee"> |
| Italian | <img width="449" alt="スクリーンショット 2023-05-26 午後6 10 59_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/4f6a8428-040b-48a3-aab5-d402b7e05580"> | <img width="450" alt="スクリーンショット 2023-05-26 午後6 24 10" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/985f8e75-7010-410a-9ede-b44e434519af"> |
| Japanese | <img width="451" alt="スクリーンショット 2023-05-26 午後6 05 50_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/02087f0c-2537-4a7f-922e-4aa709be7d9a">  | <img width="452" alt="スクリーンショット 2023-05-26 午後6 25 13" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/1a95ebff-ec28-41e5-8277-3010d072aad8"> |
| Korean | <img width="451" alt="スクリーンショット 2023-05-26 午後6 11 59_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/8bae8cb6-eb6f-4cb5-b8ff-139fe626a680"> | <img width="450" alt="スクリーンショット 2023-05-26 午後6 26 00" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/babf737b-1e9c-477e-a1a5-ec73ef4c4239"> |
| Norwegian Bokmål (Norway) | <img width="449" alt="スクリーンショット 2023-05-26 午後6 12 28_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/f1cad324-e74b-4812-afdb-a6782b22da72"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 26 56" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/9bd97ff6-2051-477e-9230-2cf9cbc4355d"> |
| Polish | <img width="452" alt="スクリーンショット 2023-05-26 午後6 14 18_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/7bd2d2b3-b97d-470b-bbf4-630d722b44e5"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 27 31" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/e541961c-c333-4b86-99d0-05a8b8a4a946"> |
| Russian | <img width="451" alt="スクリーンショット 2023-05-26 午後6 14 40_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/337d0baa-b354-4491-b4de-57edd6355510"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 27 59" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/d14bb1a1-eb66-4cbe-b1aa-bdc0d4d3dfc5"> |
| Turkish | <img width="452" alt="スクリーンショット 2023-05-26 午後6 15 03_before" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/104e41ea-3fd9-4f67-9abb-238a14acc0ad"> | <img width="451" alt="スクリーンショット 2023-05-26 午後6 28 27" src="https://github.com/SwiftcordApp/Swiftcord/assets/16385352/17b7de3b-7d10-4a37-8785-232d9c59d1bd"> |


## References

https://www.kodeco.com/29501177-attributedstring-tutorial-for-swift-getting-started

https://gist.github.com/mattyoung/5be253f8dc7ac924f23362472c5e3344