### PR TITLE
Exclude Disc from copy username if pomelo

### DIFF
--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -87,11 +87,9 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 						Spacer()
 						Button {
 							pasteboard.declareTypes([.string], owner: nil)
-							if user.discriminator != "0" {
-								pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
-							} else {
-								pasteboard.setString("\(user.username)", forType: .string)
-							}
+							pasteboard.setString(user.discriminator == "0"
+												 ? user.username
+												 : "\(user.username)#\(user.discriminator)", forType: .string)
 						} label: {
 							Image(systemName: "square.on.square")
 						}

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -87,9 +87,12 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 						Spacer()
 						Button {
 							pasteboard.declareTypes([.string], owner: nil)
-							pasteboard.setString(user.discriminator == "0"
-												 ? user.username
-												 : "\(user.username)#\(user.discriminator)", forType: .string)
+							pasteboard.setString(
+								user.discriminator == "0"
+									? user.username
+									: "\(user.username)#\(user.discriminator)",
+								forType: .string
+							)
 						} label: {
 							Image(systemName: "square.on.square")
 						}

--- a/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
+++ b/Swiftcord/Views/User/Profile/MiniUserProfileView.swift
@@ -87,7 +87,11 @@ struct MiniUserProfileView<RichContentSlot: View>: View {
 						Spacer()
 						Button {
 							pasteboard.declareTypes([.string], owner: nil)
-							pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
+							if user.discriminator != "0" {
+								pasteboard.setString("\(user.username)#\(user.discriminator)", forType: .string)
+							} else {
+								pasteboard.setString("\(user.username)", forType: .string)
+							}
 						} label: {
 							Image(systemName: "square.on.square")
 						}


### PR DESCRIPTION
Makes a change such that the discriminator is not copied for username-migrated accounts.