### PR TITLE
Fix non user badge text color in light mode

### DIFF
--- a/Swiftcord/Views/Message/MessageRenderViews/MessageView.swift
+++ b/Swiftcord/Views/Message/MessageRenderViews/MessageView.swift
@@ -19,11 +19,13 @@ struct NonUserBadge: View {
 		HStack(spacing: 0) {
 			if let flags = flags, flags.contains(.verifiedBot) {
 				Image(systemName: "checkmark")
+                    .foregroundStyle(.white)
 					.font(.system(size: 8, weight: .heavy))
 					.frame(width: 15)
 					.padding(.leading, -3)
 			}
 			Text(isWebhook ? "Webhook" : "Bot")
+                .foregroundStyle(.white)
                 .font(.system(size: 10))
                 .textCase(.uppercase)
 		}


### PR DESCRIPTION
**Issue**: Checkmark and text appeared with black color in light mode. They should be white in both dark and light. 
<img width="118" alt="Screenshot 2023-12-24 alle 10 40 23" src="https://github.com/SwiftcordApp/Swiftcord/assets/94223094/b8459e71-7da6-44df-85ae-c34c45b63d24">

